### PR TITLE
Allows user login attribute to be configured

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -9,6 +9,7 @@ This can be done like so:
     use Adldap\Adldap;
 
     $configuration = array(
+        'user_id_key' => 'samaccountname',
         'account_suffix' => '@domain.local',
         'base_dn' => 'DC=domain,DC=local',
         'domain_controllers' => array('DC1.domain.local', 'DC2.domain.local'),

--- a/src/Adldap/Adldap.php
+++ b/src/Adldap/Adldap.php
@@ -77,6 +77,13 @@ class Adldap
     protected $baseDn = "DC=mydomain,DC=local";
 
     /**
+     * The user login identifier key used in the AD schema
+     * 
+     * @var string
+     */
+    protected $userIdKey = "sAMAccountname";
+
+    /**
      * Port used to talk to the domain controllers.
      *
      * @var string
@@ -237,6 +244,11 @@ class Adldap
                     $this->setPort($configuration->{'ad_port'});
                 }
 
+                if($configuration->hasAttribute('user_id_key'))
+                {
+                    $this->setUserIdKey($configuration->{'user_id_key'});
+                }
+
                 $sso = $configuration->{'sso'};
 
                 /*
@@ -341,6 +353,28 @@ class Adldap
     public function getAccountSuffix()
     {
         return $this->accountSuffix;
+    }
+
+    /**
+    * Set the user id key
+    * 
+    * @param string $userIdKey
+    * @return void
+    */
+    public function setUserIdKey($userIdKey)
+    {
+          $this->userIdKey = $userIdKey;
+
+    }
+
+    /**
+    * Get the user id key
+    * 
+    * @return string
+    */
+    public function getUserIdKey()
+    {
+          return $this->userIdKey;
     }
 
     /**

--- a/src/Adldap/Classes/AdldapUsers.php
+++ b/src/Adldap/Classes/AdldapUsers.php
@@ -69,7 +69,7 @@ class AdldapUsers extends AdldapBase
         
         // Additional stuff only used for adding accounts
         $add["cn"][0] = $user->getAttribute("display_name");
-        $add["samaccountname"][0] = $user->getAttribute("username");
+        $add[$this->adldap->getUserIdKey()][0] = $user->getAttribute("username");
         $add["objectclass"][0] = "top";
         $add["objectclass"][1] = "person";
         $add["objectclass"][2] = "organizationalPerson";
@@ -227,7 +227,7 @@ class AdldapUsers extends AdldapBase
              $filter = "userPrincipalName=" . $username;
         } else
         {
-             $filter = "samaccountname=" . $username;
+             $filter = $this->adldap->getUserIdKey() . "=" . $username;
         }
 
         $filter = "(&(objectCategory=person)({$filter}))";
@@ -561,9 +561,11 @@ class AdldapUsers extends AdldapBase
         $this->adldap->utilities()->validateLdapIsBound();
         
         // Perform the search and grab all their details
+        $userIdKey = $this->adldap->getUserIdKey();
+
         $filter = "(&(objectClass=user)(samaccounttype=" . Adldap::ADLDAP_NORMAL_ACCOUNT .")(objectCategory=person)(cn=" . $search . "))";
 
-        $fields = array("samaccountname","displayname");
+        $fields = array("{$userIdKey}","displayname");
 
         $results = $this->connection->search($this->adldap->getBaseDn(), $filter, $fields);
 
@@ -575,13 +577,13 @@ class AdldapUsers extends AdldapBase
         {
             if ($includeDescription && strlen($entries[$i]["displayname"][0])>0)
             {
-                $usersArray[$entries[$i]["samaccountname"][0]] = $entries[$i]["displayname"][0];
+                $usersArray[$entries[$i]["{$userIdKey}"][0]] = $entries[$i]["displayname"][0];
             } elseif ($includeDescription)
             {
-                $usersArray[$entries[$i]["samaccountname"][0]] = $entries[$i]["samaccountname"][0];
+                $usersArray[$entries[$i]["{$userIdKey}"][0]] = $entries[$i]["{$userIdKey}"][0];
             } else
             {
-                array_push($usersArray, $entries[$i]["samaccountname"][0]);
+                array_push($usersArray, $entries[$i]["{$userIdKey}"][0]);
             }
         }
 
@@ -602,7 +604,7 @@ class AdldapUsers extends AdldapBase
 
         $this->adldap->utilities()->validateLdapIsBound();
         
-        $filter = "samaccountname=" . $username;
+        $filter = $this->adldap->getUserIdKey() . "=" . $username;
 
         $fields = array("objectGUID");
 
@@ -647,9 +649,11 @@ class AdldapUsers extends AdldapBase
             }
         }
 
+        $userIdKey = $this->adldap->getUserIdKey();
+
         $filter = "(&(objectClass=user)(samaccounttype=" . Adldap::ADLDAP_NORMAL_ACCOUNT .")(objectCategory=person)" . $searchParams . ")";
 
-        $fields = array("samaccountname","displayname");
+        $fields = array("{$userIdKey}","displayname");
 
         $results = $this->connection->search($this->adldap->getBaseDn(), $filter, $fields);
 
@@ -661,15 +665,15 @@ class AdldapUsers extends AdldapBase
         {
             if ($includeDescription && strlen($entries[$i]["displayname"][0]) > 0)
             {
-                $usersArray[$entries[$i]["samaccountname"][0]] = $entries[$i]["displayname"][0];
+                $usersArray[$entries[$i]["{$userIdKey}"][0]] = $entries[$i]["displayname"][0];
             }
             else if ($includeDescription)
             {
-                $usersArray[$entries[$i]["samaccountname"][0]] = $entries[$i]["samaccountname"][0];
+                $usersArray[$entries[$i]["{$userIdKey}"][0]] = $entries[$i]["{$userIdKey}"][0];
             }
             else
             {
-                array_push($usersArray, $entries[$i]["samaccountname"][0]);
+                array_push($usersArray, $entries[$i]["{$userIdKey}"][0]);
             }
         }
 


### PR DESCRIPTION
Creates one new configuration option: the primary user login attribute / identifier (defaults to "samaccountname"), instead of the previously hard-coded options of either GUID, samaccountname, or userPrincipalName. In many places (like the find method) this was simply set as samaccountname, which might not be used in the AD schema in some organizations.