### PR TITLE
Fix auth with invalid credentials exception

### DIFF
--- a/src/Adldap/Adldap.php
+++ b/src/Adldap/Adldap.php
@@ -825,9 +825,12 @@ class Adldap
         // Bind as the user
         $ret = true;
 
-        $bound = $this->bindUsingCredentials($username, $password);
-
-        if ( ! $bound) $ret = false;
+        try {
+            $bound = $this->bindUsingCredentials($username, $password);
+        }
+        catch (AdldapException $e) {
+            $ret = false;
+        }
 
         if($preventRebind)
         {
@@ -837,7 +840,7 @@ class Adldap
             $adminUsername = $this->getAdminUsername();
             $adminPassword = $this->getAdminPassword();
 
-            if($adminUsername && $adminPassword)
+            if($adminUsername !== NULL && $adminPassword !== NULL)
             {
                 $bound = $this->bindUsingCredentials($adminUsername, $adminPassword);
 


### PR DESCRIPTION
*Issue:* User authentication seems to work fine if the credentials are correct. However, when invalid credentials are presented to the `Adldap->authenticate()`, an Exception is thrown. As a side-effect, the rebind is never done, so subsequent auth attempts always fail.

An Exception is probably fine for invalid administrator bind credentials, but if a user mis-types their password, `authenticate()` should probably just return false.

*Fix:* Catch the exception and return false. Also, add the additional not-null check to administrator credentials before rebinding (to support anonymous bind via blank-string administrator credentials).