### PR TITLE
Added configuration setting for "person" search filter

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -11,6 +11,7 @@ This can be done like so:
     $configuration = array(
         'user_id_key' => 'samaccountname',
         'account_suffix' => '@domain.local',
+        'person_filter' => array('category' => 'objectCategory', 'person' => 'person'),
         'base_dn' => 'DC=domain,DC=local',
         'domain_controllers' => array('DC1.domain.local', 'DC2.domain.local'),
         'admin_username' => 'administrator',

--- a/src/Adldap/Adldap.php
+++ b/src/Adldap/Adldap.php
@@ -84,6 +84,13 @@ class Adldap
     protected $userIdKey = "sAMAccountname";
 
     /**
+     * The attribute (index 0) and value (index 1) used to identify a person in the AD schema
+     * 
+     * @var array
+     */
+    protected $personFilter = array("category" => "objectCategory", "person" => "person");
+
+    /**
      * Port used to talk to the domain controllers.
      *
      * @var string
@@ -249,6 +256,11 @@ class Adldap
                     $this->setUserIdKey($configuration->{'user_id_key'});
                 }
 
+                if($configuration->hasAttribute('person_filter'))
+                {
+                    $this->setPersonFilter($configuration->{'person_filter'});
+                }
+
                 $sso = $configuration->{'sso'};
 
                 /*
@@ -375,6 +387,35 @@ class Adldap
     public function getUserIdKey()
     {
           return $this->userIdKey;
+    }
+
+    /**
+     * Sets the person search filter
+     * 
+     * @param array $personKey
+     */
+    public function setPersonFilter($personFilter)
+    {
+        $this->personFilter = $personFilter;
+    }
+
+    /**
+     * Get the person search filter.
+     * An optional parameter may be used to specify the desired part.
+     * Without a parameter, returns an imploded string of the form "category=person".
+     *
+     * @param string $key
+     * @return string
+     */
+    public function getPersonFilter($key = null)
+    {
+        if ($key == 'category') {
+            return $this->personFilter['category'];
+        }
+        if ($key == 'person') {
+            return $this->personFilter['person'];
+        }
+        return implode('=', $this->personFilter);
     }
 
     /**

--- a/src/Adldap/Classes/AdldapUsers.php
+++ b/src/Adldap/Classes/AdldapUsers.php
@@ -214,10 +214,13 @@ class AdldapUsers extends AdldapBase
 
         $this->adldap->utilities()->validateLdapIsBound();
 
+        $personCategory = $this->adldap->getPersonFilter('category');
+        $person = $this->adldap->getPersonFilter('person');
+
         $search = $this->adldap
             ->search()
             ->select($fields)
-            ->where('objectCategory', '=', 'person');
+            ->where($personCategory, '=', $person);
 
         // Make sure we assign the default fields if none are given
         if (count($fields) === 0) $fields = $this->defaultQueryFields;
@@ -553,8 +556,9 @@ class AdldapUsers extends AdldapBase
         
         // Perform the search and grab all their details
         $userIdKey = $this->adldap->getUserIdKey();
+        $personFilter = $this->adldap->getPersonFilter();
 
-        $filter = "(&(objectClass=user)(samaccounttype=" . Adldap::ADLDAP_NORMAL_ACCOUNT .")(objectCategory=person)(cn=" . $search . "))";
+        $filter = "(&(objectClass=user)(samaccounttype=" . Adldap::ADLDAP_NORMAL_ACCOUNT .")({$personFilter})(cn=" . $search . "))";
 
         $fields = array("{$userIdKey}","displayname");
 
@@ -641,8 +645,9 @@ class AdldapUsers extends AdldapBase
         }
 
         $userIdKey = $this->adldap->getUserIdKey();
+        $personFilter = $this->adldap->getPersonFilter();
 
-        $filter = "(&(objectClass=user)(samaccounttype=" . Adldap::ADLDAP_NORMAL_ACCOUNT .")(objectCategory=person)" . $searchParams . ")";
+        $filter = "(&(objectClass=user)(samaccounttype=" . Adldap::ADLDAP_NORMAL_ACCOUNT .")({$personFilter})" . $searchParams . ")";
 
         $fields = array("{$userIdKey}","displayname");
 


### PR DESCRIPTION
Abstracted the standard "objectCategory=person" search filter into a configuration setting, in case it is needed for a particular AD schema (like my organization's weird one!).

The default is still "objectCategory=person".

The config setting is an array in order to separate the attribute and value to better fit with the new search().