### PR TITLE
Add possibility of 'dn' attribute & fix defaultQueryFields assignment loc

### DIFF
--- a/src/Adldap/Classes/AdldapUsers.php
+++ b/src/Adldap/Classes/AdldapUsers.php
@@ -214,6 +214,9 @@ class AdldapUsers extends AdldapBase
 
         $this->adldap->utilities()->validateLdapIsBound();
 
+        // Make sure we assign the default fields if none are given
+        if (count($fields) === 0) $fields = $this->defaultQueryFields;
+
         $personCategory = $this->adldap->getPersonFilter('category');
         $person = $this->adldap->getPersonFilter('person');
 
@@ -221,9 +224,6 @@ class AdldapUsers extends AdldapBase
             ->search()
             ->select($fields)
             ->where($personCategory, '=', $person);
-
-        // Make sure we assign the default fields if none are given
-        if (count($fields) === 0) $fields = $this->defaultQueryFields;
 
         if ($isGUID === true)
         {

--- a/src/Adldap/Objects/LdapEntry.php
+++ b/src/Adldap/Objects/LdapEntry.php
@@ -70,9 +70,9 @@ class LdapEntry extends AbstractObject
         }
 
         // Does the entry contain a distinguished name?
-        if(array_key_exists('distinguishedname', $attributes))
+        if(array_key_exists('dn', $attributes) || array_key_exists('distinguishedname', $attributes))
         {
-            $dn = $attributes['distinguishedname'][0];
+            $dn = (array_key_exists('dn', $attributes)) ? $attributes['dn'] : $attributes['distinguishedname'][0];
 
             // We'll assign the string distinguished name
             $this->setAttribute('dn', $dn);


### PR DESCRIPTION
- Add possibility of 'dn' generic attribute for distinguished name in the ldap server response: sometimes the distinguished name is returned as a 'dn' attribute instead of 'distinguished name'. I can only personally test the former, but I don't think this commit should mess up the latter.
- Fix defaultQueryFields assignment location: the default query fields were being assigned too late in the adldapusers->info() method to have the desired effect. Fixed!

Okay, now I'm going to sleep :)