### PR TITLE
Real password change

### DIFF
--- a/src/Classes/AdldapUsers.php
+++ b/src/Classes/AdldapUsers.php
@@ -458,17 +458,6 @@ class AdldapUsers extends AdldapBase
     }
 
     /**
-     * Check if the php installation is able to perform a password change.
-     * Requires PHP 5.4 >= 5.4.26, PHP 5.5 >= 5.5.10 or PHP 5.6 >= 5.6.0
-     *
-     * @return bool
-     */
-    private function changePasswordSupported()
-    {
-        return function_exists('ldap_modify_batch');
-    }
-
-    /**
      * Change the password of a user - This must be performed over SSL
      * Requires PHP 5.4 >= 5.4.26, PHP 5.5 >= 5.5.10 or PHP 5.6 >= 5.6.0
      *
@@ -494,7 +483,7 @@ class AdldapUsers extends AdldapBase
             throw new AdldapException($message);
         }
 
-        if ( ! $this->changePasswordSupported())
+        if ( ! $this->connection->isBatchSupported())
         {
             $message = 'Missing function support [ldap_modify_batch] http://php.net/manual/en/function.ldap-modify-batch.php';
 

--- a/src/Classes/AdldapUsers.php
+++ b/src/Classes/AdldapUsers.php
@@ -507,12 +507,12 @@ class AdldapUsers extends AdldapBase
             array (
                 'attrib'  => 'unicodePwd',
                 'modtype' => LDAP_MODIFY_BATCH_REMOVE,
-                'values'  => $this->encodePassword($oldPassword)
+                'values'  => array($this->encodePassword($oldPassword)),
             ),
             array (
                 'attrib'  => 'unicodePwd',
                 'modtype' => LDAP_MODIFY_BATCH_ADD,
-                'values'  => $this->encodePassword($password)
+                'values'  => array($this->encodePassword($password))
             )
         );
 

--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -501,6 +501,20 @@ class Ldap implements ConnectionInterface
     }
 
     /**
+     * Batch modifies the specified LDAP entry.
+     *
+     * @param string $dn
+     * @param array $entry
+     * @return bool
+     */
+    public function modifyBatch($dn, array $entry)
+    {
+        if($this->suppressErrors) return @ldap_modify_batch($this->getConnection(), $dn, $entry);
+
+        return ldap_modify_batch($this->getConnection(), $dn, $entry);
+    }
+
+    /**
      * Add attribute values to current attributes.
      *
      * @param string $dn

--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -123,6 +123,20 @@ class Ldap implements ConnectionInterface
     }
 
     /**
+     * Returns true / false if the current if the current
+     * PHP install supports batch modification.
+     * Requires PHP 5.4 >= 5.4.26, PHP 5.5 >= 5.5.10 or PHP 5.6 >= 5.6.0
+     *
+     * @return bool
+     */
+    public function isBatchSupported()
+    {
+        if ( ! function_exists('ldap_modify_batch')) return false;
+
+        return true;
+    }
+
+    /**
      * Returns true / false if the
      * current connection instance is using
      * SSL.

--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -618,6 +618,26 @@ class Ldap implements ConnectionInterface
     }
 
     /**
+     * Return the extended LDAP error code of the last LDAP command
+     *
+     * @return int
+     */
+    public function getExtendedError()
+    {
+        return $this->getDiagnosticMessage();
+    }
+
+    /**
+     * Return the extended LDAP error code of the last LDAP command
+     *
+     * @return int
+     */
+    public function getExtendedErrorCode()
+    {
+        return $this->extractDiagnosticCode( $this->getExtendedError() );
+    }
+
+    /**
      * Convert LDAP error number into string error message
      *
      * @param int $number
@@ -759,5 +779,33 @@ class Ldap implements ConnectionInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Return the diagnostic Message
+     *
+     * @return string $diagnosticMessage
+     */
+    public function getDiagnosticMessage()
+    {
+        ldap_get_option($this->getConnection(), LDAP_OPT_ERROR_STRING, $diagnosticMessage);
+
+        return $diagnosticMessage;
+    }
+
+    /**
+     * Extract the diagnostic code from the message
+     *
+     * @return string $diagnosticCode
+     */
+    public function extractDiagnosticCode($message)
+    {
+        preg_match('/^([\da-fA-F]+):/', $message, $matches);
+
+        if(! isset($matches[1])){
+            return false;
+        }
+
+        return $matches[1];
     }
 }

--- a/src/Exceptions/PasswordPolicyException.php
+++ b/src/Exceptions/PasswordPolicyException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Adldap\Exceptions;
+
+class PasswordPolicyException extends AdldapException {}

--- a/src/Exceptions/WrongPasswordException.php
+++ b/src/Exceptions/WrongPasswordException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Adldap\Exceptions;
+
+class WrongPasswordException extends AdldapException {}

--- a/src/Interfaces/ConnectionInterface.php
+++ b/src/Interfaces/ConnectionInterface.php
@@ -267,6 +267,16 @@ interface ConnectionInterface
     public function modify($dn, array $entry);
 
     /**
+     * Batch modifies an existing entry on the
+     * current connection.
+     *
+     * @param string $dn
+     * @param array $entry
+     * @return mixed
+     */
+    public function modifyBatch($dn, array $entry);
+
+    /**
      * Add attribute values to current attributes.
      *
      * @param string $dn

--- a/src/Interfaces/ConnectionInterface.php
+++ b/src/Interfaces/ConnectionInterface.php
@@ -331,6 +331,20 @@ interface ConnectionInterface
     public function errNo();
 
     /**
+     * Returns the extended error string of the last command
+     *
+     * @return mixed
+     */
+    public function getExtendedError();
+
+    /**
+     * Returns the extended error code of the last command
+     *
+     * @return mixed
+     */
+    public function getExtendedErrorCode();
+
+    /**
      * Explodes a distinguished name into an array
      *
      * @param string $dn The distinguished name

--- a/src/Interfaces/ConnectionInterface.php
+++ b/src/Interfaces/ConnectionInterface.php
@@ -42,6 +42,15 @@ interface ConnectionInterface
 
     /**
      * Returns true / false if the
+     * current connection supports batch
+     * modification.
+     *
+     * @return bool
+     */
+    public function isBatchSupported();
+
+    /**
+     * Returns true / false if the
      * current connection instance is using
      * SSL.
      *


### PR DESCRIPTION
As I mentioned on #18, I implemented a real password change.

The main difference to the `password()` method is that the password won't be set but changed.

Scenario: A user forgot his password and an admin has to reset it.
Solution: `user()->password($username, $newPassword)`
**Note:** In my environment, the password can ignore some password policies! Therefore that's not a good solution if a user just has/wants to change his password.

That's the situation where the new `changePassword()` should be used.

Scenario: A user wants to change his password.
Solution: `user()->changePassword($username, $newPassword, $oldPassword)`

That's how you normally change a password. You have to specify your old and your new password.

To give the user better feedback, I also parse the diagnostic LDAP error. It's used to get a little bit more specific error: Old password wrong or password policy violation.
I think the default error for booth situations is a little bit generic: `LDAP_CONSTRAINT_VIOLATION` and won't help to much.

I'm open for suggestions if you have concerns or naming improvements.
