### PR TITLE
Correclty handle an empty LDAP escape ignore string

### DIFF
--- a/src/Classes/Utilities.php
+++ b/src/Classes/Utilities.php
@@ -67,7 +67,7 @@ class Utilities
         }
 
         // Convert ignore string into an array
-        $ignores = str_split($ignore);
+        $ignores = self::ignoreStrToArray($ignore);
 
         // Convert the value to a hex string
         $hex = bin2hex($value);
@@ -111,7 +111,7 @@ class Utilities
     protected static function escapeManualWithFlags($value, $ignore = '', $flags = 0)
     {
         // Convert ignore string into an array
-        $ignores = str_split($ignore);
+        $ignores = self::ignoreStrToArray($ignore);
 
         $escapeFilter = ['\\', '*', '(', ')'];
         $escapeDn = ['\\', ',', '=', '+', '<', '>', ';', '"', '#'];
@@ -261,5 +261,20 @@ class Utilities
     public static function convertWindowsTimeToUnixTime($windowsTime)
     {
         return round($windowsTime / 10000000) - 11644473600;
+    }
+
+    /**
+     * @param string $ignore
+     * @return array
+     */
+    private static function ignoreStrToArray($ignore)
+    {
+        $ignore = trim($ignore);
+
+        if (!empty($ignore)) {
+            return str_split($ignore);
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
It took me a while to figure out, why my queries don't work on PHP 5.4.
The workaround method for `ldap_escape()` had a bug, where an empty `$ignore` string is handled incorrectly.

`str_split('')` returns an array with one empty value, so the `foreach` loop loops one time with the empty string, effectively removing all backslashes from the escaped value.

This bugfix checks for an empty string and correctly returns an empty array.

Maybe that's also the cause for issue #26?