### PR TITLE
Fixed authentication when you try to authenticate with authenticate()

### DIFF
--- a/src/Adldap.php
+++ b/src/Adldap.php
@@ -283,7 +283,7 @@ class Adldap
      *
      * @return bool
      */
-    public function authenticate($username, $password, $preventRebind = false)
+    public function authenticate($username, $password, $preventRebind = true)
     {
         $auth = false;
 
@@ -315,7 +315,11 @@ class Adldap
             $adminUsername = $this->configuration->getAdminUsername();
             $adminPassword = $this->configuration->getAdminPassword();
 
-            $this->bindUsingCredentials($adminUsername, $adminPassword);
+            if(empty($adminUsername) || empty($adminPassword)) {
+                throw new AdldapException('Can\'t rebind. Adminusername or password is missing');
+            }
+            
+            $auth = $this->bindUsingCredentials($adminUsername, $adminPassword);
 
             if (!$this->connection->isBound()) {
                 throw new AdldapException('Rebind to Active Directory failed. AD said: '.$this->connection->getLastError());

--- a/src/Adldap.php
+++ b/src/Adldap.php
@@ -315,7 +315,7 @@ class Adldap
             $adminUsername = $this->configuration->getAdminUsername();
             $adminPassword = $this->configuration->getAdminPassword();
 
-            if(empty($adminUsername) || empty($adminPassword)) {
+            if (empty($adminUsername) || empty($adminPassword)) {
                 throw new AdldapException('Can\'t rebind. Adminusername or password is missing');
             }
             


### PR DESCRIPTION
When you try to authenticate using the method authenticate(username, password) and you don't specify not to rebind, then you are authenticated using you specified credentials and then it tries to rebind even if you didn't specified the admin credentials in config.
I changed the behaviour to always not to rebind and when you want to rebind it checks if adminusername and password are specified.
What is the usecase to rebind as admin even when my normal authentication worked?