### PR TITLE
Added the ability to search / filter for disabled and enabled objects

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -659,7 +659,7 @@ class Builder
      */
     public function whereEnabled($enabled = true)
     {
-        if($enabled) {
+        if ($enabled) {
             $this->rawFilter('(!(UserAccountControl:1.2.840.113556.1.4.803:=2))');
         } else {
             $this->rawFilter('(UserAccountControl:1.2.840.113556.1.4.803:=2)');

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -652,32 +652,24 @@ class Builder
 
     /**
      * Adds a enabled filter to the current query.
-     *
-     * @param bool $enabled
      * 
      * @return Builder
      */
-    public function whereEnabled($enabled = true)
+    public function whereEnabled()
     {
-        if ($enabled) {
-            $this->rawFilter('(!(UserAccountControl:1.2.840.113556.1.4.803:=2))');
-        } else {
-            $this->rawFilter('(UserAccountControl:1.2.840.113556.1.4.803:=2)');
-        }
+        $this->rawFilter('(!(UserAccountControl:1.2.840.113556.1.4.803:=2))');
 
         return $this;
     }
 
     /**
      * Adds a disabled filter to the current query.
-     *
-     * @param bool $disabled
      * 
      * @return Builder
      */
-    public function whereDisabled($disabled = true)
+    public function whereDisabled()
     {
-        $this->whereEnabled(!$disabled);
+        $this->rawFilter('(UserAccountControl:1.2.840.113556.1.4.803:=2)');
 
         return $this;
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -651,6 +651,38 @@ class Builder
     }
 
     /**
+     * Adds a enabled filter to the current query.
+     *
+     * @param bool $enabled
+     * 
+     * @return Builder
+     */
+    public function whereEnabled($enabled = true)
+    {
+        if($enabled) {
+            $this->rawFilter('(!(UserAccountControl:1.2.840.113556.1.4.803:=2))');
+        } else {
+            $this->rawFilter('(UserAccountControl:1.2.840.113556.1.4.803:=2)');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds a disabled filter to the current query.
+     *
+     * @param bool $disabled
+     * 
+     * @return Builder
+     */
+    public function whereDisabled($disabled = true)
+    {
+        $this->whereEnabled(!$disabled);
+
+        return $this;
+    }
+
+    /**
      * Adds an or where clause to the current query.
      *
      * @param string      $field

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -535,6 +535,24 @@ class BuilderTest extends UnitTestCase
         $this->assertEquals($expected, $b->getQuery());
     }
 
+    public function testBuiltWhereEnabled()
+    {
+        $b = $this->newBuilder();
+
+        $b->whereEnabled();
+
+        $this->assertEquals('(!(UserAccountControl:1.2.840.113556.1.4.803:=2))', $b->getQuery());
+    }
+
+    public function testBuiltWhereDisabled()
+    {
+        $b = $this->newBuilder();
+
+        $b->whereDisabled();
+
+        $this->assertEquals('(UserAccountControl:1.2.840.113556.1.4.803:=2)', $b->getQuery());
+    }
+
     public function testNewCollection()
     {
         $b = $this->newBuilder();


### PR DESCRIPTION
I often search for enabled or disabled objects only.

The filter for that is not that easy to remember. Therefore I think such a little shortcut would be great.

What do you think?

The pull request is not final. I think the filter `(UserAccountControl:1.2.840.113556.1.4.803:=2)` should be extracted somewhere else.