### PR TITLE
fix port setting not work problem

### DIFF
--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -383,7 +383,7 @@ class Ldap implements ConnectionInterface
             $protocol = $this::PROTOCOL_SSL;
         }
 
-        return $this->connection = ldap_connect($protocol.$hostname, $port);
+        return $this->connection = ldap_connect($protocol.$hostname.':'.$port);
     }
 
     /**


### PR DESCRIPTION
use ldap://hostname:port or ldaps://hostname:port LDAP URL for connection.
reference: https://secure.php.net/manual/en/function.ldap-connect.php
#172 