### PR TITLE
Replaced LDAP_MODIFY_BATCH_REMOVE with .._REPLACE due to 'Constraint'…

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -814,18 +814,12 @@ class User extends Entry
 
         $attribute = ActiveDirectory::UNICODE_PASSWORD;
 
-        $remove = new BatchModification();
-        $remove->setAttribute($attribute);
-        $remove->setType(LDAP_MODIFY_BATCH_REMOVE);
-        $remove->setValues([Utilities::encodePassword($oldPassword)]);
+        $replace = new BatchModification();
+        $replace->setAttribute($attribute);
+        $replace->setType(LDAP_MODIFY_BATCH_REPLACE);
+        $replace->setValues([Utilities::encodePassword($newPassword)]);
 
-        $add = new BatchModification();
-        $add->setAttribute($attribute);
-        $add->setType(LDAP_MODIFY_BATCH_ADD);
-        $add->setValues([Utilities::encodePassword($newPassword)]);
-
-        $this->addModification($remove);
-        $this->addModification($add);
+        $this->addModification($replace);
 
         $result = $this->update();
 


### PR DESCRIPTION
… errors.

The previous code was causing 'Constraint' errors from AD LDAP due to the fact that it was first removing the unicodePwd then adding it back. I tested this in my production and development environment.

One caveat to this is that it makes the `$oldPassword` parameter obsolete.

If anyone has a problem with this I'm willing to create a different pull request that will add an optional parameter for an alternate way to process the password change so that both methods can exist. I may do this anyway.