### PR TITLE
Set default port for SSL connections if not specified.

### DIFF
--- a/src/Connections/Configuration.php
+++ b/src/Connections/Configuration.php
@@ -137,7 +137,7 @@ class Configuration
             );
         }
 
-        if (!key_exists('port', $options)) {
+        if (!array_key_exists('port', $options)) {
             $options['port'] = ConnectionInterface::PORT_SSL;
         }
 

--- a/src/Connections/Configuration.php
+++ b/src/Connections/Configuration.php
@@ -137,6 +137,10 @@ class Configuration
             );
         }
 
+        if (!key_exists('port', $options)) {
+            $options['port'] = ConnectionInterface::PORT_SSL;
+        }
+
         foreach ($options as $key => $value) {
             $method = 'set'.$this->normalizeKey($key);
             if (method_exists($this, $method)) {

--- a/src/Connections/Configuration.php
+++ b/src/Connections/Configuration.php
@@ -137,8 +137,10 @@ class Configuration
             );
         }
 
-        if (!array_key_exists('port', $options)) {
-            $options['port'] = ConnectionInterface::PORT_SSL;
+        if (array_key_exists('use_ssl', $options)) {
+            if (!array_key_exists('port', $options) && $options['use_ssl'] === true) {
+                $options['port'] = ConnectionInterface::PORT_SSL;
+            }
         }
 
         foreach ($options as $key => $value) {

--- a/tests/Connections/ConfigurationTest.php
+++ b/tests/Connections/ConfigurationTest.php
@@ -22,6 +22,17 @@ class ConfigurationTest extends UnitTestCase
         $this->assertFalse($config->getUseTLS());
     }
 
+    public function testDefaultOverrideForSSL()
+    {
+        $settings = [
+            'use_ssl' => true,
+        ];
+
+        $config = new Configuration($settings);
+
+        $this->assertEquals('636', $config->getPort());
+    }
+
     public function testDynamicSetUp()
     {
         $settings = [
@@ -116,6 +127,7 @@ class ConfigurationTest extends UnitTestCase
 
         $this->assertTrue($config->getUseSSL());
     }
+
 
     public function testSetUseSSLWhenUsingTLS()
     {


### PR DESCRIPTION
Now that you guys fixed the port specification we need to set to the default port for SSL connections. This will set the default port to `ConnectionInterface::PORT_SSL` (636) if the configuration array key `port` is not set.