### PR TITLE
Incorrect doc & comileOrWhere Logic improvement

### DIFF
--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -303,9 +303,9 @@ class Grammar
             $ors .= $this->compileWhere($where);
         }
 
-        // Make sure we wrap the query in an 'and' if using
-        // multiple wheres. For example (&QUERY).
-        if (count($builder->getOrWheres()) > 0) {
+        // Make sure we wrap the query in an 'or' if using
+        // multiple orWheres. For example (|(QUERY)(ORWHEREQUERY)).
+        if (($query !== '' && count($builder->getOrWheres()) > 0) || count($builder->getOrWheres()) > 1) {
             $query .= $this->compileOr($ors);
         }
 


### PR DESCRIPTION
Pretty sure that doc should be an 'or' not an 'and'

Additionally, just reading through this, if you didn't have an existing query, and you added an orWhere clause it would have generated `(|(QUERY))` which i'm not sure if LDAP handles but even if it did it would be the same net result as `(QUERY)`.