### PR TITLE
Update distinguishedName for OpenLDAP to just dn

### DIFF
--- a/src/Schemas/OpenLDAP.php
+++ b/src/Schemas/OpenLDAP.php
@@ -19,4 +19,12 @@ class OpenLDAP extends ActiveDirectory
     {
         return 'inetorgperson';
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function distinguishedName()
+    {
+        return 'dn';
+    }
 }


### PR DESCRIPTION
In OpenLDAP I believe the default attribute name for Distinguished Name is just dn. This change helps make it possible to find a record, make changes, and save it again. There is a separate issue that may cause breaks so I'll open a different issue for that.