### PR TITLE
Add schema method for getting DN subkey - fixes support for OpenLDAP

### DIFF
--- a/src/Contracts/Schemas/SchemaInterface.php
+++ b/src/Contracts/Schemas/SchemaInterface.php
@@ -207,6 +207,18 @@ interface SchemaInterface
     public function distinguishedName();
 
     /**
+     * The LDAP API references an LDAP object by its distinguished name (DN).
+     *
+     * Different vendors expect the value of the distinguished name to be in
+     * different places. For example ActiveDirectory expects distinguishedname
+     * value to be the first element in an array, however OpenLDAP expects
+     * the dn attribute to contain the value, not an array.
+     *
+     * @return integer|null
+     */
+    public function distinguishedNameSubKey();
+
+    /**
      * Name of computer as registered in DNS.
      *
      * @link https://msdn.microsoft.com/en-us/library/ms675524(v=vs.85).aspx

--- a/src/Contracts/Schemas/SchemaInterface.php
+++ b/src/Contracts/Schemas/SchemaInterface.php
@@ -214,7 +214,7 @@ interface SchemaInterface
      * value to be the first element in an array, however OpenLDAP expects
      * the dn attribute to contain the value, not an array.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function distinguishedNameSubKey();
 

--- a/src/Models/AbstractModel.php
+++ b/src/Models/AbstractModel.php
@@ -494,7 +494,10 @@ abstract class AbstractModel implements ArrayAccess, JsonSerializable
      */
     public function getDistinguishedName()
     {
-        return $this->getAttribute($this->schema->distinguishedName(), 0);
+        return $this->getAttribute(
+            $this->schema->distinguishedName(),
+            $this->schema->distinguishedNameSubKey()
+        );
     }
 
     /**

--- a/src/Schemas/ActiveDirectory.php
+++ b/src/Schemas/ActiveDirectory.php
@@ -182,6 +182,14 @@ class ActiveDirectory implements SchemaInterface
     /**
      * {@inheritdoc}
      */
+    public function distinguishedNameSubKey()
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function dnsHostName()
     {
         return 'dnshostname';

--- a/src/Schemas/OpenLDAP.php
+++ b/src/Schemas/OpenLDAP.php
@@ -27,4 +27,12 @@ class OpenLDAP extends ActiveDirectory
     {
         return 'dn';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function distinguishedNameSubKey()
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
I believe this solution will continue to support Active Directory as well as add support for OpenLDAP. The problem I was having was after using a query with findOrFail and getting back a User model, if I made changes to attributes and attempted to save it the model did not have a dn and would fail. 

This change will look to the schema object to determine what the sub key should be for retrieving the distinguished name. By default it returns ```0``` for AD and ```null``` for OpenLDAP.

I have tested and verified this works for me with OpenLDAP, but I've not tested with AD. 