### PR TITLE
Initial experimental support for FreeIPA

### DIFF
--- a/src/Schemas/FreeIPA.php
+++ b/src/Schemas/FreeIPA.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Adldap\Schemas;
+
+class FreeIPA extends ActiveDirectory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function objectCategory()
+    {
+        return 'objectclass';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectClassGroup()
+    {
+        return 'ipausergroup'
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function distinguishedName()
+    {
+        return 'dn';
+    }
+}


### PR DESCRIPTION
This provides a schema file for FreeIPA support.

FreeIPA is an open source identity provider built on top of Fedora's 389 Directory Server.

The LDAP schema is similar although slightly different to OpenLDAP's, so this is the schema file I have been using for authentication and group membership checks.