### PR TITLE
Adjust setting of dn to string instead of array in OpenLDAP case

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -343,7 +343,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
         $key = ($key == 'dn' ? $this->schema->distinguishedName() : $key);
 
         if (is_null($subKey)) {
-            $this->attributes[$key] = (is_array($value) ? $value : [$value]);
+            $this->attributes[$key] = (is_array($value) || $key == $this->schema->distinguishedName() ? $value : [$value]);
         } else {
             $this->attributes[$key][$subKey] = $value;
         }
@@ -534,7 +534,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      */
     public function setDistinguishedName($dn)
     {
-        return $this->setAttribute($this->schema->distinguishedName(), (string) $dn, 0);
+        return $this->setAttribute($this->schema->distinguishedName(), (string) $dn, $this->schema->distinguishedNameSubKey());
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -343,7 +343,11 @@ abstract class Model implements ArrayAccess, JsonSerializable
         $key = ($key == 'dn' ? $this->schema->distinguishedName() : $key);
 
         if (is_null($subKey)) {
-            $this->attributes[$key] = (is_array($value) || $key == $this->schema->distinguishedName() ? $value : [$value]);
+            if($key == $this->schema->distinguishedName() && is_null($this->schema->distinguishedNameSubKey())) {
+                $this->attributes[$key] = $value;
+            } else {
+                $this->attributes[$key] = (is_array($value) ? $value : [$value]);
+            }
         } else {
             $this->attributes[$key][$subKey] = $value;
         }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -343,7 +343,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
         $key = ($key == 'dn' ? $this->schema->distinguishedName() : $key);
 
         if (is_null($subKey)) {
-            if($key == $this->schema->distinguishedName() && is_null($this->schema->distinguishedNameSubKey())) {
+            if ($key == $this->schema->distinguishedName() && is_null($this->schema->distinguishedNameSubKey())) {
                 $this->attributes[$key] = $value;
             } else {
                 $this->attributes[$key] = (is_array($value) ? $value : [$value]);


### PR DESCRIPTION
Ok, so this is a weird issue with the `setAttribute` function causing it to store the DN as an array rather than a string.

Without this PR, if we are creating a new user, then saving the user will fail.
