### PR TITLE
Fix User::inGroup() when recursive has dups

### DIFF
--- a/src/Models/Traits/HasMemberOfTrait.php
+++ b/src/Models/Traits/HasMemberOfTrait.php
@@ -161,7 +161,7 @@ trait HasMemberOfTrait
             // actual groups and perform validation.
             $exists = $memberOf->filter(function (Group $parent) use ($group) {
                 return $this->validateGroup($group, $parent);
-            })->count() === 1;
+            })->count() !== 0;
 
             if (!$exists) {
                 // If the current group isn't at all contained


### PR DESCRIPTION
Checks for a non-zero value instead of exactly one since recursive searching can return duplicates.