### PR TITLE
Added Group definition for OpenLDAP

### DIFF
--- a/src/Schemas/OpenLDAP.php
+++ b/src/Schemas/OpenLDAP.php
@@ -23,6 +23,14 @@ class OpenLDAP extends ActiveDirectory
     /**
      * {@inheritdoc}
      */
+    public function objectClassGroup()
+    {
+        return 'groupOfNames';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function objectGuid()
     {
         return 'entryuuid';


### PR DESCRIPTION
I was having issues today, as the code defaulted to group.

I'm not 100% sure but I think this is the default objectclass for OpenLDAP. 