### PR TITLE
Add support for custom LDAP connection options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,10 @@ $config = [
     'use_ssl'               => false,
     'use_tls'               => false,
     'timeout'               => 5,
+    'custom_options'        => [
+        // See: http://php.net/ldap_set_option
+        LDAP_OPT_X_TLS_REQUIRE_CERT => LDAP_OPT_X_TLS_HARD
+    ]
 ];
 
 // Create a new Adldap Provider instance.
@@ -124,3 +128,9 @@ securely.
 The timeout option allows you to configure the amount of seconds to wait until your application receives a response from your LDAP server.
 
 The default is 5 seconds.
+
+### Custom options
+
+Arbitrary options can be set for the connection to fine-tune TLS and connection behavior. Please note that `LDAP_OPT_PROTOCOL_VERSION`,
+`LDAP_OPT_NETWORK_TIMEOUT` and `LDAP_OPT_REFERRALS` will be ignored if set. These are set above with the `version`, `timeout` and
+`follow_referrals` keys respectively. Valid options are listed in the [PHP documentation for ldap_set_option](http://php.net/ldap_set_option).

--- a/src/Configuration/DomainConfiguration.php
+++ b/src/Configuration/DomainConfiguration.php
@@ -32,6 +32,7 @@ class DomainConfiguration
         'admin_password' => '',
         'admin_account_prefix' => '',
         'admin_account_suffix' => '',
+        'custom_options' => [],
     ];
 
     /**

--- a/src/Connections/Provider.php
+++ b/src/Connections/Provider.php
@@ -256,10 +256,14 @@ class Provider implements ProviderInterface
             $this->connection->tls();
         }
 
-        $this->connection->setOptions([
-            LDAP_OPT_PROTOCOL_VERSION => $this->configuration->get('version'),
-            LDAP_OPT_NETWORK_TIMEOUT => $this->configuration->get('timeout'),
-            LDAP_OPT_REFERRALS => $this->configuration->get('follow_referrals')
-        ]);
+        $options = array_replace(
+            $this->configuration->get('custom_options'),
+            [
+                LDAP_OPT_PROTOCOL_VERSION => $this->configuration->get('version'),
+                LDAP_OPT_NETWORK_TIMEOUT => $this->configuration->get('timeout'),
+                LDAP_OPT_REFERRALS => $this->configuration->get('follow_referrals')
+            ]
+        );
+        $this->connection->setOptions($options);
     }
 }

--- a/tests/Configuration/DomainConfigurationTest.php
+++ b/tests/Configuration/DomainConfigurationTest.php
@@ -19,6 +19,7 @@ class DomainConfigurationTest extends TestCase
         $this->assertEmpty($config->get('base_dn'));
         $this->assertFalse($config->get('use_ssl'));
         $this->assertFalse($config->get('use_tls'));
+        $this->assertEquals([], $config->get('custom_options'));
     }
 
     public function test_construct()
@@ -36,6 +37,9 @@ class DomainConfigurationTest extends TestCase
             'account_suffix' => 'suffix',
             'use_ssl'            => true,
             'use_tls'            => false,
+            'custom_options'     => [
+                LDAP_OPT_SIZELIMIT => 1000
+            ]
         ]);
 
         $this->assertEquals(500, $config->get('port'));
@@ -49,6 +53,12 @@ class DomainConfigurationTest extends TestCase
         $this->assertEquals('prefix', $config->get('account_prefix'));
         $this->assertTrue($config->get('use_ssl'));
         $this->assertFalse($config->get('use_tls'));
+        $this->assertEquals(
+            [
+                LDAP_OPT_SIZELIMIT => 1000
+            ],
+            $config->get('custom_options')
+        );
     }
 
     /**
@@ -137,5 +147,13 @@ class DomainConfigurationTest extends TestCase
     public function test_invalid_use_tls()
     {
         new DomainConfiguration(['use_tls' => 'invalid']);
+    }
+
+    /**
+     * @expectedException \Adldap\Configuration\ConfigurationException
+     */
+    public function test_invalid_custom_options()
+    {
+        new DomainConfiguration(['custom_options' => 'invalid']);
     }
 }

--- a/tests/Connections/ProviderTest.php
+++ b/tests/Connections/ProviderTest.php
@@ -179,7 +179,10 @@ class ProviderTest extends TestCase
             ->shouldReceive('get')->withArgs(['use_tls'])->once()->andReturn(false)
             ->shouldReceive('get')->withArgs(['version'])->once()->andReturn(3)
             ->shouldReceive('get')->withArgs(['timeout'])->once()->andReturn(5)
-            ->shouldReceive('get')->withArgs(['follow_referrals'])->andReturn(false);
+            ->shouldReceive('get')->withArgs(['follow_referrals'])->andReturn(false)
+            // Setting LDAP_OPT_PROTOCOL_VERSION to "2" here enforces the documented behavior of honoring the
+            // "version" key over LDAP_OPT_PROTOCOL_VERSION in custom_options.
+            ->shouldReceive('get')->withArgs(['custom_options'])->andReturn([LDAP_OPT_PROTOCOL_VERSION => 2]);
 
         $connection = $this->mock(ConnectionInterface::class);
 


### PR DESCRIPTION
Many AD deployments use custom CA certificates. If these are not installed in the system, the application needs to dictate where they are, which requires setting `LDAP_OPT_X_TLS_CACERTDIR` or similar. This
commit adds a generic interface for that via the `custom_options` key in `DomainConfiguration`.

All documentation and unit tests have been updated and are passing on my local system.