### PR TITLE
Not equals functions added to Builder

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -660,6 +660,19 @@ class Builder
     }
 
     /**
+     * Adds a where not equals clause to the current query.
+     *
+     * @param string $field
+     * @param string $value
+     *
+     * @return Builder
+     */
+    public function whereNotEquals($field, $value)
+    {
+        return $this->where($field, Operator::$doesNotEqual, $value);
+    }
+
+    /**
      * Adds a where approximately equals clause to the current query.
      *
      * @param string $field
@@ -830,6 +843,19 @@ class Builder
     public function orWhereEquals($field, $value)
     {
         return $this->orWhere($field, Operator::$equals, $value);
+    }
+
+    /**
+     * Adds an or where not equals clause to the current query.
+     *
+     * @param string $field
+     * @param string $value
+     *
+     * @return Builder
+     */
+    public function orWhereNotEquals($field, $value)
+    {
+        return $this->orWhere($field, Operator::$doesNotEqual, $value);
     }
 
     /**

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -449,6 +449,50 @@ class BuilderTest extends TestCase
         $this->assertEquals($expected, $b->getQuery());
     }
 
+    public function test_built_where_equals()
+    {
+        $b = $this->newBuilder();
+
+        $b->whereEquals('field', 'value');
+
+        $expected = '(field=\76\61\6c\75\65)';
+
+        $this->assertEquals($expected, $b->getQuery());
+    }
+
+    public function test_built_where_not_equals()
+    {
+        $b = $this->newBuilder();
+
+        $b->whereNotEquals('field', 'value');
+
+        $expected = '(!(field=\76\61\6c\75\65))';
+
+        $this->assertEquals($expected, $b->getQuery());
+    }
+
+    public function test_built_or_where_equals()
+    {
+        $b = $this->newBuilder();
+
+        $b->orWhereEquals('field', 'value');
+
+        $expected = '(field=\76\61\6c\75\65)';
+
+        $this->assertEquals($expected, $b->getQuery());
+    }
+
+    public function test_built_or_where_not_equals()
+    {
+        $b = $this->newBuilder();
+
+        $b->orWhereNotEquals('field', 'value');
+
+        $expected = '(!(field=\76\61\6c\75\65))';
+
+        $this->assertEquals($expected, $b->getQuery());
+    }
+
     public function test_built_or_where_approximately_equals()
     {
         $b = $this->newBuilder();


### PR DESCRIPTION
Not equals functions added to builder.
Functional tests are added for the new implementation of not equals clause.
Function tests added for "equals" clause because them didn't have tests.

**Additionally these functions executed on OpenLDAP server. So results are expected.**