### PR TITLE
Yii2 integration available

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ Then run the `composer update` command in the root of your project.
 
 - [Laravel](https://github.com/Adldap2/Adldap2-Laravel)
 - [Kohana](https://github.com/Adldap2/Adldap2-Kohana)
+- [Yii2](https://github.com/edvler/yii2-adldap-module)
 
 ## Versioning
 


### PR DESCRIPTION
Version 2.X.X of yii2-adldap-module is reserved for Adldap v6.X.