### PR TITLE
Fix ldap_mod_del and Add mixid for better autocomplete

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
         "psr-4": {
             "Adldap\\Tests\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "7.0.x-dev"
+        }
     }
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1080,7 +1080,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
     /**
      * Deletes an attribute on the current entry.
      *
-     * @param string|array $attribute
+     * @param string $attribute
      * @param string|array $value
      *
      * @return bool

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1080,17 +1080,19 @@ abstract class Model implements ArrayAccess, JsonSerializable
     /**
      * Deletes an attribute on the current entry.
      *
-     * @param string $attribute
+     * @param string|array $attribute
+     * @param string|array $value
      *
      * @return bool
      */
-    public function deleteAttribute($attribute)
+    public function deleteAttribute($attribute, $value = [])
     {
         // We need to pass in an empty array as the value
         // for the attribute so AD knows to remove it.
+        
         if (
             $this->exists &&
-            $this->query->getConnection()->modDelete($this->getDn(), [$attribute => []])
+            $this->query->getConnection()->modDelete($this->getDn(), [$attribute => $value])
         ) {
             $this->syncRaw();
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1080,19 +1080,18 @@ abstract class Model implements ArrayAccess, JsonSerializable
     /**
      * Deletes an attribute on the current entry.
      *
-     * @param string $attribute
-     * @param string|array $value
+     * @param array $attribute
      *
      * @return bool
      */
-    public function deleteAttribute($attribute, $value = [])
+    public function deleteAttribute($attribute)
     {
         // We need to pass in an empty array as the value
         // for the attribute so AD knows to remove it.
         
         if (
             $this->exists &&
-            $this->query->getConnection()->modDelete($this->getDn(), [$attribute => $value])
+            $this->query->getConnection()->modDelete($this->getDn(), [$attribute])
         ) {
             $this->syncRaw();
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1080,7 +1080,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
     /**
      * Deletes an attribute on the current entry.
      *
-     * @param array $attributes
+     * @param string|array $attributes
      *
      * Delete many attributes ["memberuid" => "username"]
      * 
@@ -1093,6 +1093,9 @@ abstract class Model implements ArrayAccess, JsonSerializable
     {
         // We need to pass in an empty array as the value
         // for the attribute so AD knows to remove it.
+        if (is_string($attributes)) {
+            $attributes = [$attributes => []];
+        }        
         
         if (
             $this->exists &&

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1080,18 +1080,29 @@ abstract class Model implements ArrayAccess, JsonSerializable
     /**
      * Deletes an attribute on the current entry.
      *
-     * @param array $attribute
+     * @param array $attributes
+     *
+     * Delete many attributes
+     * $attributes = [
+     *      $attribute => $value,
+     *      $attribute => $value,
+     *      $attribute => $value,
+     * ];
+     * Delete attribute, does not depend on the number of values
+     * $attributes = [
+     *      $attribute => [],
+     * ];
      *
      * @return bool
      */
-    public function deleteAttribute($attribute)
+    public function deleteAttribute($attributes)
     {
         // We need to pass in an empty array as the value
         // for the attribute so AD knows to remove it.
         
         if (
             $this->exists &&
-            $this->query->getConnection()->modDelete($this->getDn(), [$attribute])
+            $this->query->getConnection()->modDelete($this->getDn(), $attributes)
         ) {
             $this->syncRaw();
 

--- a/src/Search/Factory.php
+++ b/src/Search/Factory.php
@@ -9,6 +9,12 @@ use Adldap\Schemas\ActiveDirectory;
 use Adldap\Schemas\SchemaInterface;
 use Adldap\Connections\ConnectionInterface;
 
+/**
+ * Class Factory
+ * @package Adldap\Search
+ *
+ * @mixin Builder
+ */
 class Factory
 {
     /**

--- a/tests/Models/EntryTest.php
+++ b/tests/Models/EntryTest.php
@@ -122,7 +122,7 @@ class EntryTest extends TestCase
 
         $entry->setRawAttributes($attributes);
 
-        $this->assertTrue($entry->deleteAttribute('cn'));
+        $this->assertTrue($entry->deleteAttribute(['cn' => []]));
     }
 
     public function test_create_attribute()


### PR DESCRIPTION
Change deleteAttribute() to use the schema, for delete many attributes for one time
$removal = array(
    "memberuid"=>"username",
    "apple-group-memberguid"=>"846DE847-D73D-428D-83A8-B95B606C511B"
);

Add mixid for better autocomplete if use OpenLdap schema
 