### PR TITLE
Construction method should not auto connect to ldap server

### DIFF
--- a/src/Connections/Provider.php
+++ b/src/Connections/Provider.php
@@ -99,12 +99,6 @@ class Provider implements ProviderInterface
         // Prepare the connection.
         $this->prepareConnection();
 
-        // Instantiate the LDAP connection.
-        $this->connection->connect(
-            $this->configuration->get('domain_controllers'),
-            $this->configuration->get('port')
-        );
-
         return $this;
     }
 
@@ -207,6 +201,12 @@ class Provider implements ProviderInterface
      */
     public function connect($username = null, $password = null)
     {
+        // Instantiate the LDAP connection.
+        $this->connection->connect(
+            $this->configuration->get('domain_controllers'),
+            $this->configuration->get('port')
+        );
+
         // Get the default guard instance.
         $guard = $this->getGuard();
 


### PR DESCRIPTION
When Connection Provider object create, the connection will connect to ldap server, this may cause app slow when ldap server no reachable.

And It against auto connect, so I move connection  connect to Provider connect method, will control by auto_connect