### PR TITLE
add userParameters for users

### DIFF
--- a/src/Models/Attributes/MBString.php
+++ b/src/Models/Attributes/MBString.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Adldap\Models\Attributes;
+
+class MBString
+{
+    /**
+     * Get the integer value of a specific character.
+     *
+     * @param $string
+     * @return int
+     */
+    public static function ord($string)
+    {
+        if (self::isMbstringLoaded()) {
+            $result = unpack('N', mb_convert_encoding($string, 'UCS-4BE', 'UTF-8'));
+            if (is_array($result) === true) {
+                return $result[1];
+            }
+        }
+
+        return ord($string);
+    }
+
+    /**
+     * Get the character for a specific integer value.
+     *
+     * @param $int
+     * @return string
+     */
+    public static function chr($int)
+    {
+        if (self::isMbstringLoaded()) {
+            return mb_convert_encoding(pack('n', $int), 'UTF-8', 'UTF-16BE');
+        }
+
+        return chr($int);
+    }
+
+    /**
+     * Split a string into its individual characters and return it as an array.
+     *
+     * @param string $value
+     * @return string[]
+     */
+    public static function str_split($value)
+    {
+        return preg_split('/(?<!^)(?!$)/u', $value);
+    }
+
+    /**
+     * Simple check for the mbstring extension.
+     *
+     * @return bool
+     */
+    protected static function isMbstringLoaded()
+    {
+        return extension_loaded('mbstring');
+    }
+}

--- a/src/Models/Attributes/TSProperty.php
+++ b/src/Models/Attributes/TSProperty.php
@@ -94,6 +94,7 @@ class TSProperty
     public function setName($name)
     {
         $this->name = $name;
+        return $this;
     }
 
     /**
@@ -114,6 +115,7 @@ class TSProperty
     public function setValue($value)
     {
         $this->value = $value;
+        return $this;
     }
 
     /**

--- a/src/Models/Attributes/TSProperty.php
+++ b/src/Models/Attributes/TSProperty.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Adldap\Models\Attributes;
+
+class TSProperty
+{
+    /**
+     * Nibble control values. The first value for each is if the nibble is <= 9, otherwise the second value is used.
+     */
+    const NIBBLE_CONTROL = [
+        'X' => ['001011', '011010'],
+        'Y' => ['001110', '011010'],
+    ];
+
+    /**
+     * The nibble header.
+     */
+    const NIBBLE_HEADER = '1110';
+
+    /**
+     * Conversion factor needed for time values in the TSPropertyArray (stored in microseconds).
+     */
+    const TIME_CONVERSION = 60 * 1000;
+
+    /**
+     * A simple map to help determine how the property needs to be decoded/encoded from/to its binary value.
+     *
+     * There are some names that are simple repeats but have 'W' at the end. Not sure as to what that signifies. I
+     * cannot find any information on them in Microsoft documentation. However, their values appear to stay in sync with
+     * their non 'W' counterparts. But not doing so when manipulating the data manually does not seem to affect anything.
+     * This probably needs more investigation.
+     *
+     * @var array
+     */
+    protected $propTypes = [
+        'string' => [
+            'CtxWFHomeDir',
+            'CtxWFHomeDirW',
+            'CtxWFHomeDirDrive',
+            'CtxWFHomeDirDriveW',
+            'CtxInitialProgram',
+            'CtxInitialProgramW',
+            'CtxWFProfilePath',
+            'CtxWFProfilePathW',
+            'CtxWorkDirectory',
+            'CtxWorkDirectoryW',
+            'CtxCallbackNumber',
+        ],
+        'time' => [
+            'CtxMaxDisconnectionTime',
+            'CtxMaxConnectionTime',
+            'CtxMaxIdleTime',
+        ],
+        'int' => [
+            'CtxCfgFlags1',
+            'CtxCfgPresent',
+            'CtxKeyboardLayout',
+            'CtxMinEncryptionLevel',
+            'CtxNWLogonServer',
+            'CtxShadow',
+        ],
+    ];
+
+    /**
+     * @var string The property name.
+     */
+    protected $name;
+
+    /**
+     * @var string|int The property value.
+     */
+    protected $value;
+
+    /**
+     * @var int The property value type.
+     */
+    protected $valueType = 1;
+
+    /**
+     * @param string|null $value Pass binary TSProperty data to construct its object representation.
+     */
+    public function __construct($value = null)
+    {
+        if ($value) {
+            $this->decode(bin2hex($value));
+        }
+    }
+
+    /**
+     * Set the name for the TSProperty.
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Get the name for the TSProperty.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the value for the TSProperty.
+     *
+     * @param string|int $value
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Get the value for the TSProperty.
+     *
+     * @return string|int
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Convert the TSProperty name/value back to its binary representation for the userParameters blob.
+     *
+     * @return string
+     */
+    public function toBinary()
+    {
+        $name = bin2hex($this->name);
+        $binValue = $this->getEncodedValueForProp($this->name, $this->value);
+        $valueLen = strlen(bin2hex($binValue)) / 3;
+
+        $binary = hex2bin(
+            $this->dec2hex(strlen($name))
+            .$this->dec2hex($valueLen)
+            .$this->dec2hex($this->valueType)
+            .$name
+        );
+
+        return $binary.$binValue;
+    }
+
+    /**
+     * Given a TSProperty blob, decode the name/value/type/etc.
+     *
+     * @param string $tsProperty
+     */
+    protected function decode($tsProperty)
+    {
+        $nameLength = hexdec(substr($tsProperty, 0, 2));
+        # 1 data byte is 3 encoded bytes
+        $valueLength = hexdec(substr($tsProperty, 2, 2)) * 3;
+
+        $this->valueType = hexdec(substr($tsProperty, 4, 2));
+        $this->name = pack('H*', substr($tsProperty, 6, $nameLength));
+        $this->value = $this->getDecodedValueForProp($this->name, substr($tsProperty, 6 + $nameLength, $valueLength));
+    }
+
+    /**
+     * Based on the property name/value in question, get its encoded form.
+     *
+     * @param string $propName
+     * @param string|int $propValue
+     * @return string
+     */
+    protected function getEncodedValueForProp($propName, $propValue)
+    {
+        if (in_array($propName, $this->propTypes['string'])) {
+            # Simple strings are null terminated. Unsure if this is needed or simply a product of how ADUC does stuff?
+            $value = $this->encodePropValue($propValue."\0", true);
+        } elseif (in_array($propName, $this->propTypes['time'])) {
+            # Needs to be in microseconds (assuming it is in minute format)...
+            $value = $this->encodePropValue($propValue * self::TIME_CONVERSION);
+        } else {
+            $value = $this->encodePropValue($propValue);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Based on the property name in question, get its actual value from the binary blob value.
+     *
+     * @param string $propName
+     * @param string $propValue
+     * @return string|int
+     */
+    protected function getDecodedValueForProp($propName, $propValue)
+    {
+        if (in_array($propName, $this->propTypes['string'])) {
+            // Strip away null terminators. I think this should be desired, otherwise it just ends in confusion.
+            $value = str_replace("\0", '', $this->decodePropValue($propValue, true));
+        } elseif (in_array($propName, $this->propTypes['time'])) {
+            // Convert from microseconds to minutes (how ADUC displays it anyway, and seems the most practical).
+            $value = hexdec($this->decodePropValue($propValue)) / self::TIME_CONVERSION;
+        } elseif (in_array($propName, $this->propTypes['int'])) {
+            $value = hexdec($this->decodePropValue($propValue));
+        } else {
+            $value = $this->decodePropValue($propValue);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Decode the property by inspecting the nibbles of each blob, checking the control, and adding up the results into
+     * a final value.
+     *
+     * @param string $hex
+     * @param bool $string Whether or not this is simple string data.
+     * @return string
+     */
+    protected function decodePropValue($hex, $string = false)
+    {
+        $decodePropValue = '';
+        $blobs = str_split($hex, 6);
+
+        foreach ($blobs as $blob) {
+            $bin = decbin(hexdec($blob));
+            $controlY = substr($bin, 4, 6);
+            $nibbleY = substr($bin, 10, 4);
+            $controlX = substr($bin, 14, 6);
+            $nibbleX = substr($bin, 20, 4);
+            $byte = $this->nibbleControl($nibbleX, $controlX).$this->nibbleControl($nibbleY, $controlY);
+            if ($string) {
+                $decodePropValue .= MBString::chr(bindec($byte));
+            } else {
+                $decodePropValue = $this->dec2hex(bindec($byte)).$decodePropValue;
+            }
+        }
+
+        return $decodePropValue;
+    }
+
+    /**
+     * Get the encoded property value as a binary blob.
+     *
+     * @param string $value
+     * @param bool $string
+     * @return string
+     */
+    protected function encodePropValue($value, $string = false)
+    {
+        // An int must be properly padded. (then split and reversed). For a string, we just split the chars. This seems
+        // to be the easiest way to handle UTF-8 characters instead of trying to work with their hex values.
+        $chars = $string ? MBString::str_split($value) : array_reverse(str_split($this->dec2hex($value, 8), 2));
+
+        $encoded = '';
+        foreach ($chars as $char) {
+            // Get the bits for the char. Using this method to ensure it is fully padded.
+            $bits = sprintf('%08b', $string ? MBString::ord($char) : hexdec($char));
+            $nibbleX = substr($bits, 0, 4);
+            $nibbleY = substr($bits, 4, 4);
+
+            // Construct the value with the header, high nibble, then low nibble.
+            $value = self::NIBBLE_HEADER;
+            foreach (['Y' => $nibbleY, 'X' => $nibbleX] as $nibbleType => $nibble) {
+                $value .= $this->getNibbleWithControl($nibbleType, $nibble);
+            }
+
+            // Convert it back to a binary bit stream
+            foreach ([0, 8, 16] as $start) {
+                $encoded .= $this->packBitString(substr($value, $start, 8), 8);
+            }
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * PHP's pack() function has no 'b' or 'B' template. This is a workaround that turns a literal bit-string into a
+     * packed byte-string with 8 bits per byte.
+     *
+     * @param string $bits
+     * @param bool $len
+     * @return string
+     */
+    protected function packBitString($bits, $len)
+    {
+        $bits = substr($bits, 0, $len);
+        // Pad input with zeros to next multiple of 4 above $len
+        $bits = str_pad($bits, 4 * (int) (($len + 3) / 4), '0');
+
+        // Split input into chunks of 4 bits, convert each to hex and pack them
+        $nibbles = str_split($bits, 4);
+        foreach ($nibbles as $i => $nibble) {
+            $nibbles[$i] = base_convert($nibble, 2, 16);
+        }
+
+        return pack('H*', implode('', $nibbles));
+    }
+
+    /**
+     * Based on the control, adjust the nibble accordingly.
+     *
+     * @param string $nibble
+     * @param string $control
+     * @return string
+     */
+    protected function nibbleControl($nibble, $control)
+    {
+        // This control stays constant for the low/high nibbles, so it doesn't matter which we compare to
+        if ($control == self::NIBBLE_CONTROL['X'][1]) {
+            $dec = bindec($nibble);
+            $dec += 9;
+            $nibble = str_pad(decbin($dec), 4, '0', STR_PAD_LEFT);
+        }
+
+        return $nibble;
+    }
+
+    /**
+     * Get the nibble value with the control prefixed.
+     *
+     * If the nibble dec is <= 9, the control X equals 001011 and Y equals 001110, otherwise if the nibble dec is > 9
+     * the control for X or Y equals 011010. Additionally, if the dec value of the nibble is > 9, then the nibble value
+     * must be subtracted by 9 before the final value is constructed.
+     *
+     * @param string $nibbleType Either X or Y
+     * @param $nibble
+     * @return string
+     */
+    protected function getNibbleWithControl($nibbleType, $nibble)
+    {
+        $dec = bindec($nibble);
+
+        if ($dec > 9) {
+            $dec -= 9;
+            $control = self::NIBBLE_CONTROL[$nibbleType][1];
+        } else {
+            $control = self::NIBBLE_CONTROL[$nibbleType][0];
+        }
+
+        return $control.sprintf('%04d', decbin($dec));
+    }
+
+    /**
+     * Need to make sure hex values are always an even length, so pad as needed.
+     *
+     * @param int $int
+     * @param int $padLength The hex string must be padded to this length (with zeros).
+     * @return string
+     */
+    protected function dec2hex($int, $padLength = 2)
+    {
+        return str_pad(dechex($int), $padLength, 0, STR_PAD_LEFT);
+    }
+}

--- a/src/Models/Attributes/TSPropertyArray.php
+++ b/src/Models/Attributes/TSPropertyArray.php
@@ -73,9 +73,7 @@ class TSPropertyArray
             $tsPropertyArray = $tsPropertyArray ?: self::DEFAULTS;
             foreach ($tsPropertyArray as $key => $value) {
                 $tsProperty = new TSProperty();
-                $tsProperty->setName($key);
-                $tsProperty->setValue($value);
-                $this->tsProperty[$key] = $tsProperty;
+                $this->tsProperty[$key] = $tsProperty->setName($key)->setValue($value);
             }
         } else {
             $this->decodeUserParameters($tsPropertyArray);

--- a/src/Models/Attributes/TSPropertyArray.php
+++ b/src/Models/Attributes/TSPropertyArray.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Adldap\Models\Attributes;
+
+class TSPropertyArray
+{
+    /**
+     * Represents that the TSPropertyArray data is valid.
+     */
+    const VALID_SIGNATURE = 'P';
+
+    /**
+     * @var array The default values for the TSPropertyArray structure.
+     */
+    const DEFAULTS = [
+        'CtxCfgPresent' => 2953518677,
+        'CtxWFProfilePath' => '',
+        'CtxWFProfilePathW' => '',
+        'CtxWFHomeDir' => '',
+        'CtxWFHomeDirW' => '',
+        'CtxWFHomeDirDrive' => '',
+        'CtxWFHomeDirDriveW' => '',
+        'CtxShadow' => 1,
+        'CtxMaxDisconnectionTime' => 0,
+        'CtxMaxConnectionTime' => 0,
+        'CtxMaxIdleTime' => 0,
+        'CtxWorkDirectory' => '',
+        'CtxWorkDirectoryW' => '',
+        'CtxCfgFlags1' => 2418077696,
+        'CtxInitialProgram' => '',
+        'CtxInitialProgramW' => '',
+    ];
+
+    /**
+     * @var string The default data that occurs before the TSPropertyArray (CtxCfgPresent with a bunch of spaces...?)
+     */
+    protected $defaultPreBinary = '43747843666750726573656e742020202020202020202020202020202020202020202020202020202020202020202020';
+
+    /**
+     * @var TSProperty[]
+     */
+    protected $tsProperty = [];
+
+    /**
+     * @var string
+     */
+    protected $signature = self::VALID_SIGNATURE;
+
+    /**
+     * @var string Binary data that occurs before the TSPropertyArray data in userParameters.
+     */
+    protected $preBinary = '';
+
+    /**
+     * @var string Binary data that occurs after the TSPropertyArray data in userParameters.
+     */
+    protected $postBinary = '';
+
+    /**
+     * Construct in one of the following ways:
+     *
+     *   - Pass an array of TSProperty key => value pairs (See DEFAULTS constant).
+     *   - Pass the userParameters binary value. The object representation of that will be decoded and constructed.
+     *   - Pass nothing and a default set of TSProperty key => value pairs will be used (See DEFAULTS constant).
+     *
+     * @param mixed $tsPropertyArray
+     */
+    public function __construct($tsPropertyArray = null)
+    {
+        $this->preBinary = hex2bin($this->defaultPreBinary);
+
+        if (is_null($tsPropertyArray) || is_array($tsPropertyArray)) {
+            $tsPropertyArray = $tsPropertyArray ?: self::DEFAULTS;
+            foreach ($tsPropertyArray as $key => $value) {
+                $tsProperty = new TSProperty();
+                $tsProperty->setName($key);
+                $tsProperty->setValue($value);
+                $this->tsProperty[$key] = $tsProperty;
+            }
+        } else {
+            $this->decodeUserParameters($tsPropertyArray);
+        }
+    }
+
+    /**
+     * Check if a specific TSProperty exists by its property name.
+     *
+     * @param string $propName
+     * @return bool
+     */
+    public function has($propName)
+    {
+        return array_key_exists(strtolower($propName), array_change_key_case($this->tsProperty));
+    }
+
+    /**
+     * Get a TSProperty object by its property name (ie. CtxWFProfilePath).
+     *
+     * @param string $propName
+     * @return TSProperty
+     */
+    public function get($propName)
+    {
+        $this->validateProp($propName);
+
+        return $this->getTsPropObj($propName)->getValue();
+    }
+
+    /**
+     * Add a TSProperty object. If it already exists, it will be overwritten.
+     *
+     * @param TSProperty $tsProperty
+     * @return $this
+     */
+    public function add(TSProperty $tsProperty)
+    {
+        $this->tsProperty[$tsProperty->getName()] = $tsProperty;
+
+        return $this;
+    }
+
+    /**
+     * Remove a TSProperty by its property name (ie. CtxMinEncryptionLevel).
+     *
+     * @param string $propName
+     * @return $this
+     */
+    public function remove($propName)
+    {
+        foreach (array_keys($this->tsProperty) as $property) {
+            if (strtolower($propName) == strtolower($property)) {
+                unset($this->tsProperty[$property]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the value for a specific TSProperty by its name.
+     *
+     * @param string $propName
+     * @param mixed $propValue
+     * @return $this
+     */
+    public function set($propName, $propValue)
+    {
+        $this->validateProp($propName);
+        $this->getTsPropObj($propName)->setValue($propValue);
+
+        return $this;
+    }
+
+    /**
+     * Get the full binary representation of the userParameters containing the TSPropertyArray data.
+     *
+     * @return string
+     */
+    public function toBinary()
+    {
+        $binary = $this->preBinary;
+
+        $binary .= hex2bin(str_pad(dechex(MBString::ord($this->signature)), 2, 0, STR_PAD_LEFT));
+        $binary .= hex2bin(str_pad(dechex(count($this->tsProperty)), 2, 0, STR_PAD_LEFT));
+        foreach ($this->tsProperty as $tsProperty) {
+            $binary .= $tsProperty->toBinary();
+        }
+
+        return $binary.$this->postBinary;
+    }
+
+    /**
+     * Get a simple associative array containing of all TSProperty names and values.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $userParameters = [];
+
+        foreach ($this->tsProperty as $property => $tsPropObj) {
+            $userParameters[$property] = $tsPropObj->getValue();
+        }
+
+        return $userParameters;
+    }
+
+    /**
+     * Get all TSProperty objects.
+     *
+     * @return TSProperty[]
+     */
+    public function getTSProperties()
+    {
+        return $this->tsProperty;
+    }
+
+    /**
+     * @param string $propName
+     */
+    protected function validateProp($propName)
+    {
+        if (!$this->has($propName)) {
+            throw new \InvalidArgumentException(sprintf('TSProperty for "%s" does not exist.', $propName));
+        }
+    }
+
+    /**
+     * @param string $propName
+     * @return TSProperty
+     */
+    protected function getTsPropObj($propName)
+    {
+        return array_change_key_case($this->tsProperty)[strtolower($propName)];
+    }
+
+    /**
+     * Get an associative array with all of the userParameters property names and values.
+     *
+     * @param string $userParameters
+     * @return array
+     */
+    protected function decodeUserParameters($userParameters)
+    {
+        $userParameters = bin2hex($userParameters);
+
+        // Save the 96-byte array of reserved data, so as to not ruin anything that may be stored there.
+        $this->preBinary = hex2bin(substr($userParameters, 0, 96));
+        // The signature is a 2-byte unicode character at the front
+        $this->signature = MBString::chr(hexdec(substr($userParameters, 96, 2)));
+        // This asserts the validity of the tsPropertyArray data. For some reason 'P' means valid...
+        if ($this->signature != self::VALID_SIGNATURE) {
+            throw new \InvalidArgumentException('Invalid TSPropertyArray data');
+        }
+
+        // The property count is a 2-byte unsigned integer indicating the number of elements for the tsPropertyArray
+        // It starts at position 98. The actual variable data begins at position 100.
+        $length = $this->addTSPropData(substr($userParameters, 100), hexdec(substr($userParameters, 98, 2)));
+
+        // Reserved data length + (count and sig length == 4) + the added lengths of the TSPropertyArray
+        // This saves anything after that variable TSPropertyArray data, so as to not squash anything stored there
+        if (strlen($userParameters) > (96 + 4 + $length)) {
+            $this->postBinary = hex2bin(substr($userParameters, (96 + 4 + $length)));
+        }
+    }
+
+    /**
+     * Given the start of TSPropertyArray hex data, and the count for the number of TSProperty structures in contains,
+     * parse and split out the individual TSProperty structures. Return the full length of the TSPropertyArray data.
+     *
+     * @param string $tsPropertyArray
+     * @param int $tsPropCount
+     * @return int The length of the data in the TSPropertyArray
+     */
+    protected function addTSPropData($tsPropertyArray, $tsPropCount)
+    {
+        $length = 0;
+
+        for ($i = 0; $i < $tsPropCount; $i++) {
+            // Prop length = name length + value length + type length + the space for the length data.
+            $propLength = hexdec(substr($tsPropertyArray, $length, 2)) + (hexdec(substr($tsPropertyArray, $length + 2, 2)) * 3) + 6;
+            $tsProperty = new TSProperty(hex2bin(substr($tsPropertyArray, $length, $propLength)));
+            $this->tsProperty[$tsProperty->getName()] = $tsProperty;
+            $length += $propLength;
+        }
+
+        return $length;
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1062,6 +1062,28 @@ class User extends Entry implements Authenticatable
     }
 
     /**
+     * Return the user parameters.
+     *
+     * @return $this
+     */
+    public function getUserParameters()
+    {
+        return new \Adldap\Models\Attributes\TSPropertyArray($this->getFirstAttribute('userparameters'));
+    }
+
+    /**
+     * Sets the user parameters.
+     *
+     * @param \Adldap\Models\Attributes\TSPropertyArray $userParameters
+     *
+     * @return $this
+     */
+    public function setUserParameters($userParameters)
+    {
+        return $this->setFirstAttribute('userparameters', $userParameters->toBinary());
+    }
+
+    /**
      * Retrieves the primary group of the current user.
      *
      * @return Model|bool

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -253,4 +253,62 @@ class UserTest extends TestCase
 
         $this->assertFalse($user->passwordExpired());
     }
+
+    public function test_get_userparameters()
+    {
+        $model = $this->newUserModel([
+            'userparameters' => (new \Adldap\Models\Attributes\TSPropertyArray(['CtxInitialProgram'=>'C:\\path\\bin.exe','CtxWorkDirectory'=>'C:\\path\\']))->toBinary()
+        ]);
+
+        $parameters = $model->getUserParameters();
+
+        $this->assertInstanceOf(\Adldap\Models\Attributes\TSPropertyArray::class, $parameters);
+        $this->assertTrue($parameters->has('CtxInitialProgram'));
+        $this->assertFalse($parameters->has('PropertyDoesNotExist'));
+        $this->assertEquals('C:\\path\\', $parameters->get('CtxWorkDirectory'));
+    }
+
+    public function test_set_userparameters()
+    {
+        $model = $this->newUserModel([
+            'userparameters' => (new \Adldap\Models\Attributes\TSPropertyArray(['CtxInitialProgram'=>'C:\\path\\bin.exe','CtxWorkDirectory'=>'C:\\path\\']))->toBinary()
+        ]);
+
+        $parameters = $model->getUserParameters();
+
+        $parameters->set('CtxInitialProgram', 'C:\\path\\otherbin.exe');
+
+        $model->setUserParameters($parameters);
+
+        $this->assertTrue($parameters->has('CtxInitialProgram'));
+        $this->assertEquals('C:\\path\\otherbin.exe', $parameters->get('CtxInitialProgram'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function test_set_inexistant_userparameters()
+    {
+        $model = $this->newUserModel([
+            'userparameters' => (new \Adldap\Models\Attributes\TSPropertyArray(['CtxInitialProgram'=>'C:\\path\\bin.exe','CtxWorkDirectory'=>'C:\\path\\']))->toBinary()
+        ]);
+
+        $parameters = $model->getUserParameters();
+
+        $parameters->set('CtxWFHomeDir', '/home/');
+    }
+
+    public function test_add_userparameters()
+    {
+        $model = $this->newUserModel([
+            'userparameters' => (new \Adldap\Models\Attributes\TSPropertyArray(['CtxInitialProgram'=>'C:\\path\\bin.exe','CtxWorkDirectory'=>'C:\\path\\']))->toBinary()
+        ]);
+
+        $parameters = $model->getUserParameters();
+
+        $parameters->add((new \Adldap\Models\Attributes\TSProperty())->setName('CtxInitialProgram')->setValue('C:\\path\\otherbin.exe'));
+
+        $this->assertTrue($parameters->has('CtxInitialProgram'));
+        $this->assertEquals('C:\\path\\otherbin.exe', $parameters->get('CtxInitialProgram'));
+    }
 }


### PR DESCRIPTION
Decode / Encode userparamters in ActiveDirectory
userparameters is used in ActiveDirectory to set the TerminalServicesInitialProgram and TerminalServicesWorkDirectory properties.

How use :

// get userparameters :
        $tsPropArray = $user->getUserParameters();

// update : 
	$tsPropArray->set('CtxInitialProgram', 'C:\\prog.exe');
	$tsPropArray->set('CtxWorkDirectory', 'C:\\');
	$user->setUserParameters($tsPropArray);