### PR TITLE
FreeIPA GUID is named ipaUniqueId

### DIFF
--- a/src/Schemas/FreeIPA.php
+++ b/src/Schemas/FreeIPA.php
@@ -81,7 +81,7 @@ class FreeIPA extends BaseSchema
      */
     public function objectGuid()
     {
-        return 'objectguid';
+        return 'ipauniqueid';
     }
 
     /**


### PR DESCRIPTION
This breaks the built-in auth in the Laravel module because `getConvertedGuid` never returns a value.