### PR TITLE
Add getDetailedError, enabling LDAP_OPT_DIAGNOSTIC_MESSAGE

### DIFF
--- a/src/AdldapError.php
+++ b/src/AdldapError.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Adldap;
+
+/**
+ * Class AdldapError
+ *
+ * Detailed information class for errors returned by getDetailedError()
+ * @package Adldap
+ */
+class AdldapError
+{
+    /**
+     * @var int the error code from ldap_errno
+     */
+    private $errorCode = null;
+    /**
+     * @var string the error message from ldap_error
+     */
+    private $errorMessage = null;
+    /**
+     * @var string the diagnostic message when retrieved after an ldap_error
+     */
+    private $diagnosticMessage = null;
+
+    /**
+     * AdldapError constructor.
+     * @param $errorCode
+     * @param $errorMessage
+     * @param $diagnosticMessage
+     */
+    public function __construct($errorCode, $errorMessage, $diagnosticMessage)
+    {
+        $this->errorCode = $errorCode;
+        $this->errorMessage = $errorMessage;
+        $this->diagnosticMessage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+    /**
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+    /**
+     * @return string
+     */
+    public function getDiagnosticMessage()
+    {
+        return $this->diagnosticMessage;
+    }
+}

--- a/src/Connections/ConnectionInterface.php
+++ b/src/Connections/ConnectionInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Adldap\Connections;
+use Adldap\AdldapError;
 
 /**
  * The Connection interface used for making connections. Implementing
@@ -198,6 +199,15 @@ interface ConnectionInterface
      * @return string
      */
     public function getLastError();
+
+    /**
+     * Return detailed information about an error
+     * Returns false when there was a successful last request.
+     * Returns AdldapError when there was an error, with detailed information.
+     *
+     * @return bool|AdldapError
+     */
+    public function getDetailedError();
 
     /**
      * Get all binary values from the specified result entry.

--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -2,6 +2,7 @@
 
 namespace Adldap\Connections;
 
+use Adldap\AdldapError;
 use Adldap\AdldapException;
 
 /**
@@ -165,6 +166,29 @@ class Ldap implements ConnectionInterface
     public function getLastError()
     {
         return ldap_error($this->getConnection());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDetailedError()
+    {
+        $diagMessage = '';
+        $errorNumber = ldap_errno($this->getConnection());
+
+        // if we have a returned value of 0, there was nothing but success!
+        // http://php.net/manual/en/function.ldap-errno.php
+        if ($errorNumber == 0) {
+            return false;
+        }
+
+        $errorString = ldap_err2str($errorNumber);
+
+        if (defined('LDAP_OPT_DIAGNOSTIC_MESSAGE')) {
+            $diagMessage = ldap_get_option($this->getConnection(), LDAP_OPT_DIAGNOSTIC_MESSAGE, $err);
+        }
+
+        return new AdldapError($errorNumber, $errorString, $diagMessage);
     }
 
     /**


### PR DESCRIPTION
If I had this while trying to sort out why #560 wasn't working, my life would have been so much easier!

This adds a new piece of functionality to the Ldap connection to retrieve detailed diagnostic messages from the LDAP server.

`->getLastError()` just returns the basic LDAP error, while `getDetailedError()` will return much more detailed information about what is actually failing.

For instance, if you attempt a `bind()` with a username and password for a User that has an expired password, `getLastError()` will not tell you the exact reason for the login failing, giving you a generic '`Bind Failed`' as the cause. When calling `getDetailedError()`, you will receive a more detailed message from the AD server as to why the login failed (ie, it will tell you that the user's password has expired).