### PR TITLE
add ForeignSecurityPrincipal class for linked domains

### DIFF
--- a/src/Models/ForeignSecurityPrincipal.php
+++ b/src/Models/ForeignSecurityPrincipal.php
@@ -1,0 +1,16 @@
+<?php
+namespace Adldap\Models;
+
+use Adldap\Models\Concerns\HasMemberOf;
+
+/**
+ * Class ForeignSecurityPrincipal
+ *
+ * Represents an LDAP ForeignSecurityPrincipal.
+ *
+ * @package Adldap\Models
+ */
+class ForeignSecurityPrincipal extends Entry
+{
+    use HasMemberOf;
+}

--- a/src/Schemas/Schema.php
+++ b/src/Schemas/Schema.php
@@ -10,6 +10,7 @@ use Adldap\Models\Printer;
 use Adldap\Models\Computer;
 use Adldap\Models\Container;
 use Adldap\Models\OrganizationalUnit;
+use Adldap\Models\ForeignSecurityPrincipal;
 
 abstract class Schema implements SchemaInterface
 {
@@ -667,16 +668,25 @@ abstract class Schema implements SchemaInterface
     /**
      * {@inheritdoc}
      */
+    public function objectClassForeignSecurityPrincipal()
+    {
+        return 'foreignsecurityprincipal';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function objectClassModelMap()
     {
         return [
-            $this->objectClassComputer()    => $this->computerModel(),
-            $this->objectClassContact()     => $this->contactModel(),
-            $this->objectClassPerson()      => $this->userModel(),
-            $this->objectClassGroup()       => $this->groupModel(),
-            $this->objectClassContainer()   => $this->containerModel(),
-            $this->objectClassPrinter()     => $this->printerModel(),
-            $this->objectClassOu()          => $this->organizationalUnitModel(),
+            $this->objectClassComputer()                    => $this->computerModel(),
+            $this->objectClassContact()                     => $this->contactModel(),
+            $this->objectClassPerson()                      => $this->userModel(),
+            $this->objectClassGroup()                       => $this->groupModel(),
+            $this->objectClassContainer()                   => $this->containerModel(),
+            $this->objectClassPrinter()                     => $this->printerModel(),
+            $this->objectClassOu()                          => $this->organizationalUnitModel(),
+            $this->objectClassForeignSecurityPrincipal()    => $this->foreignSecurityPrincipalModel()
         ];
     }
 
@@ -1188,5 +1198,15 @@ abstract class Schema implements SchemaInterface
     public function versionNumber()
     {
         return 'versionnumber';
+    }
+
+    /**
+     * The class name of the foreignSecurityPrincipal model.
+     *
+     * @return string
+     */
+    public function foreignSecurityPrincipalModel()
+    {
+        return ForeignSecurityPrincipal::class;
     }
 }


### PR DESCRIPTION
ForeignSecurityPrincipal is an object use on approved domain, 
when a user of a domain B is member of a group of domain A, a foreignSecurityPrincipal object is create in domain A and contains the attribute memberof.