### PR TITLE
Fix for paginating groups with exponential range

### DIFF
--- a/src/Models/Group.php
+++ b/src/Models/Group.php
@@ -256,12 +256,14 @@ class Group extends Entry
             if($to === '*') {
                 return $members;
             }
+            
+            $range = $to - $matches[1][0];
 
             $from = $to + 1;
 
             // We'll determine the member range simply
-            // by doubling the selected from value.
-            $to = $from * 2;
+            // by adding $range to $from.
+            $to = $from + $range;
 
             // We'll need to query for the current model again but with
             // a new range to retrieve the other members.


### PR DESCRIPTION
Sorry if I submitted this pull request previously.  I thought I had, but I don't see it now and I didn't see the code changes in my local fork.

$to = $from * 2 caused exponential growth in the request range.
0-99
100-200
201-402
403-806
...

This code change calculates the range between from and to and uses that to set the range