### PR TITLE
Correct namespace on BindException examples

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -265,7 +265,7 @@ try {
     $provider = $ad->connect($connectionName);
 
     // Great, we're connected!
-} catch (\Adldap\Connections\BindException $e) {
+} catch (\Adldap\Auth\BindException $e) {
     // Failed to connect.
 }
 ```
@@ -299,7 +299,7 @@ $ad->addProvider($config = ['...']);
 
 try {
     $users = $ad->search()->users()->get();
-} catch (\Adldap\Connections\BindException $e) {
+} catch (\Adldap\Auth\BindException $e) {
     // Failed to connect.
 }
 ```


### PR DESCRIPTION
Another minor doc tweak. Sorry for nitpicking. I'm upgrading a project from an old version of Adldap2 not having used it before, so the docs are very fresh in my eyes.