### PR TITLE
Fixed case sensitivity problem in Model hasAttribute method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": ">=7.0",
         "ext-ldap": "*",
+        "ext-bcmath": "*",
         "tightenco/collect": "~5.0",
         "illuminate/contracts": "~5.0"
     },

--- a/src/Models/Concerns/HasAttributes.php
+++ b/src/Models/Concerns/HasAttributes.php
@@ -252,6 +252,9 @@ trait HasAttributes
      */
     public function hasAttribute($key, $subKey = null)
     {
+        // Normalize key.
+        $key = $this->normalizeAttributeKey($key);
+        
         if (is_null($subKey)) {
             return Arr::has($this->attributes, $key);
         }


### PR DESCRIPTION
Found and fixed a case sensitivity issue where the hasAttribute method would not return true if an attribute is present but with different case.

While setting up a dev instance, I found that the bcmath extension is required but not specified in composer.json.