### PR TITLE
remove bcmath dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "require": {
         "php": ">=7.0",
         "ext-ldap": "*",
-        "ext-bcmath": "*",
         "tightenco/collect": "~5.0",
         "illuminate/contracts": "~5.0"
     },

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1358,10 +1358,10 @@ class User extends Entry implements Authenticatable
             }
 
             // convert from 100 nanosecond ticks to seconds
-            $maxPasswordAge = $maxPasswordAge / 10000000;
+            $maxPasswordAgeSeconds = $maxPasswordAge / 10000000;
 
-            $lastSet = Utilities::convertWindowsTimeToUnixTime($lastSet);
-            $passwordExpiryTime = $lastSet - $maxPasswordAge;
+            $lastSetUnixEpoch = Utilities::convertWindowsTimeToUnixTime($lastSet);
+            $passwordExpiryTime = $lastSetUnixEpoch - $maxPasswordAgeSeconds;
 
             $expiresAt = (new DateTime())->setTimestamp($passwordExpiryTime);
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1357,11 +1357,11 @@ class User extends Entry implements Authenticatable
                 return false;
             }
 
-            // Get the users password expiry in Windows time.
-            $passwordExpiry = bcsub($lastSet, $maxPasswordAge);
+            // convert from 100 nanosecond ticks to seconds
+            $maxPasswordAge = $maxPasswordAge / 10000000;
 
-            // Convert the Windows time to unix.
-            $passwordExpiryTime = Utilities::convertWindowsTimeToUnixTime($passwordExpiry);
+            $lastSet = Utilities::convertWindowsTimeToUnixTime($lastSet);
+            $passwordExpiryTime = $lastSet - $maxPasswordAge;
 
             $expiresAt = (new DateTime())->setTimestamp($passwordExpiryTime);
 


### PR DESCRIPTION
Since bcmath is only used in only one place, and only in the case of the ActiveDirectory schema, I thought it made sense to eliminate the bcmath dependency.

Please look this over carefully, as I don't have an ActiveDirectory instance to test against. The unit tests pass, but that's all I can say with confidence.