### PR TITLE
Remove (!(objectclass=contact)) from users queries

### DIFF
--- a/src/Query/Factory.php
+++ b/src/Query/Factory.php
@@ -125,7 +125,6 @@ class Factory
         return $this->where([
             [$this->schema->objectClass(), Operator::$equals, $this->schema->objectClassUser()],
             [$this->schema->objectCategory(), Operator::$equals, $this->schema->objectCategoryPerson()],
-            [$this->schema->objectClass(), Operator::$doesNotEqual, $this->schema->objectClassContact()],
         ]);
     }
 

--- a/tests/Connections/ProviderTest.php
+++ b/tests/Connections/ProviderTest.php
@@ -225,7 +225,7 @@ class ProviderTest extends TestCase
         $query = $m->search()->users();
 
         $this->assertInstanceOf(Builder::class, $query);
-        $this->assertEquals('(&(objectclass=user)(objectcategory=person)(!(objectclass=contact)))', $query->getUnescapedQuery());
+        $this->assertEquals('(&(objectclass=user)(objectcategory=person))', $query->getUnescapedQuery());
     }
 
     public function test_containers()

--- a/tests/Query/FactoryTest.php
+++ b/tests/Query/FactoryTest.php
@@ -57,8 +57,8 @@ class FactoryTest extends TestCase
         $query = $search->users();
 
         $this->assertInstanceOf(Builder::class, $query);
-        $this->assertCount(3, $query->filters['and']);
-        $this->assertEquals('(&(objectclass=\75\73\65\72)(objectcategory=\70\65\72\73\6f\6e)(!(objectclass=\63\6f\6e\74\61\63\74)))', $query->getQuery());
+        $this->assertCount(2, $query->filters['and']);
+        $this->assertEquals('(&(objectclass=\75\73\65\72)(objectcategory=\70\65\72\73\6f\6e))', $query->getQuery());
     }
 
     public function test_printer_scope()


### PR DESCRIPTION
Remove (!(objectclass=contact)) from users queries, because this breaks searches and authentication.