### PR TITLE
Update FreeIPA.php

### DIFF
--- a/src/Schemas/FreeIPA.php
+++ b/src/Schemas/FreeIPA.php
@@ -79,6 +79,14 @@ class FreeIPA extends Schema
     /**
      * {@inheritdoc}
      */
+    public function objectClassUser()
+    {
+        return 'organizationalPerson';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function objectGuid()
     {
         return 'objectguid';


### PR DESCRIPTION
FreeIPA does not have the `user` objectClass, which is the returned by the Schema parent class. This class is used here:

https://github.com/Adldap2/Adldap2/blob/7518389bff23c4a48a67d04ed689851cb17910bc/src/Query/Factory.php#L126

Adding the `user` to the filter leads to an issue: No LDAP query results for filter: [(&(objectclass=user)(objectclass=person)(uid=myname))]  as described here: https://github.com/munkireport/munkireport-php/issues/1218#issuecomment-456760657

The current PR resolves that by adding `objectClassUser()` to the FreeIPA schema.