### PR TITLE
You can only upgrade the same connection once to TLS

### DIFF
--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -273,7 +273,7 @@ class Ldap implements ConnectionInterface
     public function connect($hosts = [], $port = '389')
     {
         
-        $this->upgradeToTLS = false;
+        $this->upgradedToTLS = false;
         
         $this->host = $this->getConnectionString($hosts, $this->getProtocol(), $port);
 
@@ -285,7 +285,7 @@ class Ldap implements ConnectionInterface
      */
     public function close()
     {
-        $this->upgradeToTLS = false;
+        $this->upgradedToTLS = false;
         
         $connection = $this->getConnection();
 


### PR DESCRIPTION
This PR fixes the scenario when you first bind with a bind user and then try to bind with a regular user.
The library tries to upgrade the same connection twice in this scenario.

How to reproduce:
1. Use 'use_tls' => true in your config and add a bind user
2. execute $provider = $ad->connect(); , this call will succeed
3. Try to auth attempt with another user, ie: $provider->auth()->attempt('userdn', 'password');

The auth()->attempt() call will try to upgrade the connection to TLS again which already is upgraded to TLS and therefor fails. This PR fixes that by only upgrading the same connection once.