### PR TITLE
Groups getMembers() returns more than 1 User

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "adldap2/adldap2",
+    "name": "boxcarpress/adldap2",
     "type": "library",
     "description": "A PHP LDAP Package for humans.",
     "keywords": [

--- a/src/Models/Group.php
+++ b/src/Models/Group.php
@@ -191,13 +191,13 @@ class Group extends Entry
 
         $entries = $this->getAttribute($attribute) ?: [];
 
-        $query = $this->query->newInstance();
-
         // Retrieving the member identifier to allow
         // compatibility with LDAP variants.
         $identifier = $this->schema->memberIdentifier();
 
         foreach ($entries as $entry) {
+	        $query = $this->query->newInstance();
+
             // If our identifier is a distinguished name, then we need to
             // use an alternate query method, as we can't locate records
             // by distinguished names using an LDAP filter.


### PR DESCRIPTION
Moving a new instance of the query inside the `foreach` loop makes a new query for each member. Fixes #654