### PR TITLE
Fixed the attribute fetch from schema. It should use getFirstAttribute.

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1028,7 +1028,7 @@ class User extends Entry implements Authenticatable
      */
     public function getAccountName()
     {
-        return $this->getAttribute($this->schema->accountName());
+        return $this->getFirstAttribute($this->schema->accountName());
     }
 
     /**


### PR DESCRIPTION
My bad. I didn't notice that I used the `getAttribute` (that will return an array) instead of `getFirstAttribute` (that will return an string like docblock state).