### PR TITLE
Updatede accountName so it matches OpenLdap

### DIFF
--- a/src/Schemas/OpenLDAP.php
+++ b/src/Schemas/OpenLDAP.php
@@ -7,6 +7,14 @@ class OpenLDAP extends Schema
     /**
      * {@inheritdoc}
      */
+    public function accountName()
+    {
+        return 'uid';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function distinguishedName()
     {
         return 'dn';


### PR DESCRIPTION
When importing from Openldap Account Name would be empty

```
Would you like to display the user(s) to be imported / synchronized? (yes/no) [no]:
 > yes


+--------------------------+--------------+-----+
| Name                     | Account Name | UPN |
+--------------------------+--------------+-----+
| Test Person              | test         |     |
```