### PR TITLE
Update FreeIPA.php

### DIFF
--- a/src/Schemas/FreeIPA.php
+++ b/src/Schemas/FreeIPA.php
@@ -7,6 +7,14 @@ class FreeIPA extends Schema
     /**
      * {@inheritdoc}
      */
+    public function accountName()
+    {
+        return 'uid';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function distinguishedName()
     {
         return 'dn';
@@ -26,6 +34,14 @@ class FreeIPA extends Schema
     public function objectClassGroup()
     {
         return 'ipausergroup';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function userPrincipalName()
+    {
+        return 'krbCanonicalName';
     }
 
     /**
@@ -89,7 +105,7 @@ class FreeIPA extends Schema
      */
     public function objectGuid()
     {
-        return 'objectguid';
+        return 'ipaUniqueID';
     }
 
     /**
@@ -97,6 +113,6 @@ class FreeIPA extends Schema
      */
     public function objectGuidRequiresConversion()
     {
-        return true;
+        return false;
     }
 }

--- a/src/Schemas/FreeIPA.php
+++ b/src/Schemas/FreeIPA.php
@@ -75,6 +75,14 @@ class FreeIPA extends Schema
     {
         return 'lockouttime';
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function passwordLastSet()
+    {
+        return 'krbLastPwdChange';
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
FreeIPA, version: 4.6.4 uses `ipaUniqueID` as `objectGuid` (It has been `ipaUniqueID` since V4 came out)

`krbCanonicalName` was the closet thing I could find to AD's `userprincipalname`