### PR TITLE
Small changes to configuration files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": ">=7.0",
         "ext-ldap": "*",
+        "ext-json": "*",
         "psr/log": "~1.0",
         "tightenco/collect": "~5.0",
         "illuminate/contracts": "~5.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,4 +14,9 @@
             <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
I've added `ext-json` to composer.json to keep IDEs from complaining that it is not defined in composer.

I've added `composer.lock` to .gitignore file as I do not believe this declaration should only live in your global gitignore.

I've added the `whitelist` option to phpunit.xml as it allows you to run your test-suite locally and see code coverage analysis in your IDE.