### PR TITLE
Make models directly querable from static method calls.

### DIFF
--- a/src/Connections/ProviderContainer.php
+++ b/src/Connections/ProviderContainer.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Adldap\Connections;
+
+class ProviderContainer
+{
+    /**
+     * Current instance of ProviderContainer.
+     *
+     * @var ProviderContainer $instance
+     */
+    private static $instance;
+
+    /**
+     * Providers in the container.
+     *
+     * @var array|Provider[]
+     */
+    private $providers = [];
+
+    /**
+     * The name of the default provider.
+     *
+     * @var string
+     */
+    private $default = 'default';
+
+    /**
+     * Get or set the current instance of ProviderContainer.
+     *
+     * @return ProviderContainer
+     */
+    public static function getInstance()
+    {
+        return self::$instance ?? self::getNewInstance();
+    }
+
+    /**
+     * Set and get a new instance of ProviderContainer
+     *
+     * @return ProviderContainer
+     */
+    public static function getNewInstance()
+    {
+        return self::$instance = new self();
+    }
+
+    /**
+     * A new a Provider into the container.
+     *
+     * @param ProviderInterface $provider
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function add(ProviderInterface $provider, string $name = null)
+    {
+        $this->providers[$name ?? $this->default] = $provider;
+
+        return $this;
+    }
+
+    /**
+     * Remove a Provider from the container.
+     *
+     * @param $name
+     *
+     * @return $this
+     */
+    public function remove($name)
+    {
+        if ($this->exists($name)) {
+            unset($this->providers[$name]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return all of the Provider from the container.
+     *
+     * @return array|Provider[]
+     */
+    public function all()
+    {
+        return $this->providers;
+    }
+
+    /**
+     * Get a Provider by name or return the default provider.
+     *
+     * @param string|null $name
+     *
+     * @return mixed
+     *
+     * @throws ProviderContainerException If the given provider does not exist.
+     */
+    public function get(string $name = null)
+    {
+        $name = $name ?? $this->default;
+
+        if ($this->exists($name)) {
+            return $this->providers[$name];
+        }
+
+        throw new ProviderContainerException("The connection provider '$name' does not exist.");
+    }
+
+    /**
+     * Return the default Provider.
+     *
+     * @return Provider
+     */
+    public function getDefault()
+    {
+        return $this->get($this->default);
+    }
+
+    /**
+     * Checks if the Provider exists.
+     *
+     * @param $name
+     *
+     * @return bool
+     */
+    public function exists($name): bool
+    {
+        return array_key_exists($name, $this->providers);
+    }
+
+    /**
+     * Set the default provider name;
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setDefault($name = null)
+    {
+        $name = $name ?? $this->default;
+
+        if ($this->get($name) instanceof ProviderInterface) {
+            $this->default = $name;
+        }
+
+        return $this;
+    }
+}

--- a/src/Connections/ProviderContainerException.php
+++ b/src/Connections/ProviderContainerException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Adldap\Connections;
+
+use InvalidArgumentException;
+
+class ProviderContainerException extends InvalidArgumentException
+{
+
+}

--- a/src/Query/Factory.php
+++ b/src/Query/Factory.php
@@ -3,7 +3,14 @@
 namespace Adldap\Query;
 
 use Adldap\Connections\ConnectionInterface;
+use Adldap\Models\Computer;
+use Adldap\Models\Contact;
+use Adldap\Models\Container;
+use Adldap\Models\Group;
+use Adldap\Models\OrganizationalUnit;
+use Adldap\Models\Printer;
 use Adldap\Models\RootDse;
+use Adldap\Models\User;
 use Adldap\Schemas\ActiveDirectory;
 use Adldap\Schemas\SchemaInterface;
 
@@ -17,6 +24,16 @@ use Adldap\Schemas\SchemaInterface;
  */
 class Factory
 {
+    const MODEL_SCOPES = [
+        Computer::class => 'computers',
+        Contact::class => 'contacts',
+        Container::class => 'containers',
+        Group::class => 'groups',
+        OrganizationalUnit::class => 'ous',
+        Printer::class => 'printers',
+        User::class => 'users',
+    ];
+
     /**
      * @var ConnectionInterface
      */

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -2,6 +2,8 @@
 
 namespace Adldap\Tests\Models;
 
+use Adldap\Adldap;
+use Adldap\Connections\Provider;
 use Adldap\Models\Attributes\AccountControl;
 use Adldap\Models\Attributes\TSProperty;
 use Adldap\Models\Attributes\TSPropertyArray;
@@ -19,6 +21,24 @@ class UserTest extends TestCase
         $builder = $builder ?: $this->newBuilder();
 
         return new User($attributes, $builder);
+    }
+
+    public function test_get_scoped_query_builder_on_static_call()
+    {
+        $providers = [
+            'first' => new Provider(),
+            'second' => new Provider(),
+        ];
+
+        new Adldap($providers);
+
+        $this->assertInstanceOf(Builder::class, User::where(''));
+
+        $query = User::query();
+
+        $this->assertInstanceOf(Builder::class, $query);
+        $this->assertCount(3, $query->filters['and']);
+        $this->assertEquals('(&(objectclass=\75\73\65\72)(objectcategory=\70\65\72\73\6f\6e)(!(objectclass=\63\6f\6e\74\61\63\74)))', $query->getQuery());
     }
 
     public function test_set_password_on_new_user()


### PR DESCRIPTION
Refer to [issue #675 ](https://github.com/Adldap2/Adldap2/issues/675).

This adds a `ProviderContainer` that holds all registered connection providers and allows access to them from other parts of the system.

I'm using this to allow for scoped queries on the models.

Needs more test coverage, but I think it's a good starting point.
