### PR TITLE
add userPrincipalName dedicated functions

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -597,6 +597,32 @@ abstract class Model implements ArrayAccess, JsonSerializable
     {
         return $this->setFirstAttribute($this->schema->accountName(), $accountName);
     }
+    
+    
+    /**
+     * Returns the model's userPrincipalName.
+     *
+     * @link https://docs.microsoft.com/en-us/windows/win32/adschema/a-userprincipalname
+     *
+     * @return string
+     */
+    public function getUserPrincipalName()
+    {
+        return $this->getFirstAttribute($this->schema->userPrincipalName());
+    }
+
+    /**
+     * Sets the model's userPrincipalName.
+     *
+     * @param string $upn
+     *
+     * @return Model
+     */
+    public function setUserPrincipalName($upn)
+    {
+        return $this->setFirstAttribute($this->schema->userPrincipalName(), $upn);
+    }
+
 
     /**
      * Returns the model's samaccounttype.


### PR DESCRIPTION
useful attribute, more and more recent versions, less limited than samaccountname

Reading the Schema.php and ActiveDirectory.php, I realize that a lot of 100% ActiveDirectory fields are in the base Schema. Is it related to the history of the package ? Or another reason ?