### PR TITLE
Update Model.php, $user->rename in same branch fix

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1149,8 +1149,10 @@ abstract class Model implements ArrayAccess, JsonSerializable
 
         if ($moved) {
             // If the model was successfully moved, we'll set its
-            // new DN so we can sync it's attributes properly.
-            $this->setDn("{$rdn},{$newParentDn}");
+            // new DN so we can sync its attributes properly.
+            if (!empty($newParentDn)) {
+                $this->setDn("{$rdn},{$newParentDn}");
+            }
 
             $this->syncRaw();
 


### PR DESCRIPTION
I have the use case where I rename in the same LDAP branch, so newParentDn is null. That's fine for ldap_rename builtin function but not for your setDn() method. Id setDn does not need to be called when renaming in the same branch, this fix should do the job.