### PR TITLE
Correct set options on connect

### DIFF
--- a/src/Connections/Provider.php
+++ b/src/Connections/Provider.php
@@ -117,14 +117,14 @@ class Provider implements ProviderInterface
         // We will create a standard connection if one isn't given.
         $this->connection = $connection ?: new Ldap();
 
-        // Prepare the connection.
-        $this->prepareConnection();
-
         // Instantiate the LDAP connection.
         $this->connection->connect(
             $this->configuration->get('hosts'),
             $this->configuration->get('port')
         );
+
+        // Prepare the connection.
+        $this->prepareConnection();
 
         return $this;
     }


### PR DESCRIPTION
// Reproduction on Active Directory for attribute ntSecurityDescriptor security descriptor for the schema object
// ldap_connect before ldap_set_option
// If you swap ldap_connect and ldap_set_option will not work

$ldap = ldap_connect('server');

ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
ldap_set_option($ldap, LDAP_OPT_REFERRALS, false);
ldap_set_option($ldap, LDAP_OPT_SERVER_CONTROLS, [[
    'oid' => '1.2.840.113556.1.4.801',
    'iscritical' => true,
    'value' => sprintf('%c%c%c%c%c', 48, 3, 2, 1, 7)
]]);

ldap_bind($ldap, 'DN', 'pass');

$sr = ldap_search($ldap, 'DN', '(sAMAccountName=user)', ['ntSecurityDescriptor']);
$info = ldap_get_entries($ldap, $sr);

var_damp($info);