### PR TITLE
Minimal LdapRecord pagination backport

### DIFF
--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -303,6 +303,27 @@ class Ldap implements ConnectionInterface
     }
 
     /**
+     * Extract information from an LDAP result.
+     *
+     * @link https://www.php.net/manual/en/function.ldap-parse-result.php
+     *
+     * @param resource $result
+     * @param int      $errorCode
+     * @param string   $dn
+     * @param string   $errorMessage
+     * @param array    $referrals
+     * @param array    $serverControls
+     *
+     * @return bool
+     */
+    public function parseResult($result, &$errorCode, &$dn, &$errorMessage, &$referrals, &$serverControls = [])
+    {
+		return $this->supportsServerControlsInMethods() && !empty($serverControls) ?
+			ldap_parse_result($this->connection, $result, $errorCode, $dn, $errorMessage, $referrals, $serverControls) :
+			ldap_parse_result($this->connection, $result, $errorCode, $dn, $errorMessage, $referrals);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function bind($username, $password, $sasl = false)
@@ -483,6 +504,16 @@ class Ldap implements ConnectionInterface
     public function getProtocol()
     {
         return $this->isUsingSSL() ? $this::PROTOCOL_SSL : $this::PROTOCOL;
+    }
+
+    /**
+     * Determine if the current PHP version supports server controls.
+     *
+     * @return bool
+     */
+    public function supportsServerControlsInMethods()
+    {
+        return version_compare(PHP_VERSION, '7.3.0') >= 0;
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -486,6 +486,22 @@ class Builder
      */
     protected function runPaginate($filter, $perPage, $isCritical)
     {
+        return $this->connection->supportsServerControlsInMethods() ?
+            $this->compatiblePaginationCallback($filter, $perPage, $isCritical) :
+            $this->deprecatedPaginationCallback($filter, $perPage, $isCritical);
+    }
+
+    /**
+     * Create a deprecated pagination callback compatible with PHP 7.2.
+     *
+     * @param string $filter
+     * @param int    $perPage
+     * @param bool   $isCritical
+     *
+     * @return array
+     */
+    protected function deprecatedPaginationCallback($filter, $perPage, $isCritical)
+    {
         $pages = [];
 
         $cookie = '';
@@ -510,6 +526,62 @@ class Builder
         // eliminates any further opportunity for running queries in the same request,
         // even though that is supposed to be the correct usage.
         $this->connection->controlPagedResult();
+
+        return $pages;
+    }
+
+    /**
+     * Create a compatible pagination callback compatible with PHP 7.3 and greater.
+     *
+     * @param string $filter
+     * @param int    $perPage
+     * @param bool   $isCritical
+     *
+     * @return array
+     */
+    protected function compatiblePaginationCallback($filter, $perPage, $isCritical)
+    {
+        $pages = [];
+
+        // Setup our paged results control.
+        $controls = [
+            LDAP_CONTROL_PAGEDRESULTS => [
+                'oid' => LDAP_CONTROL_PAGEDRESULTS,
+                'isCritical' => $isCritical,
+                'value' => [
+                    'size' => $perPage,
+                    'cookie' => '',
+                ],
+            ],
+        ];
+
+        do {
+            // Update the server controls.
+            $this->connection->setOption(LDAP_OPT_SERVER_CONTROLS, $controls);
+
+            // Run the search.
+            $resource = $this->run($filter);
+
+            if ($resource) {
+                $errorCode = $dn = $errorMessage = $refs = null;
+
+                // Update the server controls with the servers response.
+                $this->connection->parseResult($resource, $errorCode, $dn, $errorMessage, $refs, $controls);
+
+                $pages[] = $this->parse($resource);
+
+                // Reset paged result on the current connection. We won't pass in the current $perPage
+                // parameter since we want to reset the page size to the default '1000'. Sending '0'
+                // eliminates any further opportunity for running queries in the same request,
+                // even though that is supposed to be the correct usage.
+                $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['size'] = $perPage;
+            }
+        } while (!empty($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie']));
+
+        // After running the query, we will clear the LDAP server controls. This
+        // allows the controls to be automatically reset before each new query
+        // that is conducted on the same connection during each request.
+        $this->connection->setOption(LDAP_OPT_SERVER_CONTROLS, []);
 
         return $pages;
     }


### PR DESCRIPTION
Minimal backport of updated query pagination logic from https://github.com/DirectoryTree/LdapRecord/issues/59.

Adding fuller _controls_ support was considered out of scope as Adldap2 is not receiving new features.

Addresses #760.