### PR TITLE
New schema for 389 directory support

### DIFF
--- a/src/Schemas/Directory389.php
+++ b/src/Schemas/Directory389.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Adldap\Schemas;
+
+class Directory389 extends Schema
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function accountName()
+    {
+        return 'uid';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function distinguishedName()
+    {
+        return 'dn';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function distinguishedNameSubKey()
+    {
+        //
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterEnabled()
+    {
+        return sprintf('(!(%s=*))', $this->lockoutTime());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterDisabled()
+    {
+        return sprintf('(%s=*)', $this->lockoutTime());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lockoutTime()
+    {
+        return 'pwdAccountLockedTime';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectCategory()
+    {
+        return 'objectclass';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectClassGroup()
+    {
+        return 'groupofnames';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectClassOu()
+    {
+        return 'organizationalUnit';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectClassPerson()
+    {
+        return 'inetorgperson';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectClassUser()
+    {
+        return 'inetorgperson';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectGuid()
+    {
+        return 'nsuniqueid';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function objectGuidRequiresConversion()
+    {
+        return false;
+    }
+}

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -213,7 +213,7 @@ class Utilities
      */
     public static function isValidGuid($guid)
     {
-        return (bool) preg_match('/^([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}$/', $guid);
+        return (bool) preg_match('/^([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}$|^([0-9a-fA-F]{8}-){3}[0-9a-fA-F]{8}$/', $guid);
     }
 
     /**


### PR DESCRIPTION
389 Directory Server doesn't use entryUUID or an attribute of some kind containing a UUID as a unique structural attribute for an object (although version 1.4.4.4 recently introduced entryUUID as per RFC 4530 for openLDAP compatibility). Instead it uses nsUniqueID, which is made out of 4 sequences of 8 hexadecimal digits separated by "-" characters. So, relatively close to a UUID but not identical.
I patched the regex in the isValidGuid() to validate that format as well, althouh it might not be an actual GUID per se.