### PR TITLE
fix the data type for php8

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -595,7 +595,11 @@ class Builder
     {
         // Normalize entries. Get entries returns false on failure.
         // We'll always want an array in this situation.
-        $entries = $this->connection->getEntries($resource) ?: [];
+        if ($resource === false) {
+             $entries = []; 
+        } else { 
+            $entries = $this->connection->getEntries($resource); 
+        }
 
         // Free up memory.
         if (is_resource($resource)) {


### PR DESCRIPTION
 ldap_get_entries(resource $ldap, resource $result): array|false

If $resource is false, and sent to this function, in php8 it will cause an error " Argument #2 ($result) must be of type resource". So it should avoid this by checking if the $resource is false. 