### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,54 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+      - v9.0
+      - v8.0
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+      - v9.0
+      - v8.0
+    paths-ignore:
+      - '**.md'
+  # Allow manually triggering the workflow
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+    continue-on-error: ${{ matrix.experimental == true }}
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.0"
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+
+        include:
+          - php-version: "8.1"
+            experimental: true
+
+    name: PHP ${{ matrix.php-version }} tests
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: ldap
+          coverage: none
+
+      - uses: "ramsey/composer-install@v1"
+
+      - name: "Run PHPUnit"
+        run: ./vendor/bin/simple-phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction
 
-script: ./vendor/bin/phpunit
+script: ./vendor/bin/simple-phpunit
 
 branches:
   only:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "illuminate/contracts": "~5.0|~6.0|~7.0|~8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0|~7.0|~8.0",
+        "symfony/phpunit-bridge": "~5.2|~6.0",
         "mockery/mockery": "~1.0"
     },
     "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,7 @@
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
+    <php>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1" />
+    </php>
 </phpunit>

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -13,6 +13,7 @@ use Adldap\Schemas\SchemaInterface;
 use Adldap\Query\Events\QueryExecuted;
 use Adldap\Models\ModelNotFoundException;
 use Adldap\Connections\ConnectionInterface;
+use LDAP\Result;
 
 class Builder
 {
@@ -585,19 +586,19 @@ class Builder
     }
 
     /**
-     * Parses the given LDAP resource by retrieving its entries.
+     * Parses the given LDAP result by retrieving its entries.
      *
-     * @param resource $resource
+     * @param resource|Result $result
      *
      * @return array
      */
-    protected function parse($resource)
+    protected function parse($result)
     {
-        if (is_resource($resource)) {
-            $entries = $this->connection->getEntries($resource);
+        if (is_resource($result) || $result instanceof Result) {
+            $entries = $this->connection->getEntries($result);
             
             // Free up memory.
-            $this->connection->freeResult($resource);
+            $this->connection->freeResult($result);
         } else {
             $entries = [];
         }

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -54,7 +54,7 @@ class Processor
 
         $models = [];
 
-        if (array_key_exists('count', $entries)) {
+	if (is_array($entries) && array_key_exists('count', $entries)) {
             for ($i = 0; $i < $entries['count']; $i++) {
                 // We'll go through each entry and construct a new
                 // model instance with the raw LDAP attributes.

--- a/tests/Models/Attributes/AccountControlTest.php
+++ b/tests/Models/Attributes/AccountControlTest.php
@@ -12,7 +12,7 @@ class AccountControlTest extends TestCase
         $ac = new AccountControl();
 
         $this->assertEquals(0, $ac->getValue());
-        $this->assertInternalType('int', $ac->getValue());
+        $this->assertIsInt($ac->getValue());
     }
 
     public function test_all_options_are_applied_correctly()
@@ -54,7 +54,7 @@ class AccountControlTest extends TestCase
 
         $this->assertEquals(0, $ac->__toInt());
         $this->assertEquals(0, (int) $ac->getValue());
-        $this->assertInternalType('int', $ac->__toInt());
+        $this->assertIsInt($ac->__toInt());
     }
 
     public function test_can_be_casted_to_string()
@@ -63,7 +63,7 @@ class AccountControlTest extends TestCase
 
         $this->assertEquals('0', (string) $ac);
         $this->assertEquals('0', $ac->__toString());
-        $this->assertInternalType('string', $ac->__toString());
+        $this->assertIsString($ac->__toString());
     }
 
     public function test_multiple_flags_can_be_applied()

--- a/tests/Models/Attributes/BatchModificationTest.php
+++ b/tests/Models/Attributes/BatchModificationTest.php
@@ -138,9 +138,9 @@ class BatchModificationTest extends TestCase
             (new DistinguishedName('test')),
         ]);
 
-        $this->assertInternalType('string', $modification->getValues()[0]);
-        $this->assertInternalType('string', $modification->getValues()[1]);
-        $this->assertInternalType('string', $modification->getValues()[2]);
+        $this->assertIsString($modification->getValues()[0]);
+        $this->assertIsString($modification->getValues()[1]);
+        $this->assertIsString($modification->getValues()[2]);
     }
 
     public function test_is_valid()

--- a/tests/Models/GroupTest.php
+++ b/tests/Models/GroupTest.php
@@ -267,9 +267,11 @@ class GroupTest extends TestCase
             ]
         )->andReturn(true);
 
+        $result = $this->newResult();
         $connection
-            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn(['count' => 1])
-            ->shouldReceive('getEntries')->once()->with(['count' => 1])->andReturn($group);
+            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)->andReturn($group)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertTrue($group->addMembers($members));
     }
@@ -303,9 +305,11 @@ class GroupTest extends TestCase
             ]
         )->andReturn(true);
 
+        $result = $this->newResult();
         $connection
-            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn(['count' => 1])
-            ->shouldReceive('getEntries')->once()->with(['count' => 1])->andReturn($group);
+            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)->andReturn($group)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertTrue($group->addMembers($members));
     }
@@ -335,9 +339,11 @@ class GroupTest extends TestCase
             ]
         )->andReturn(true);
 
+        $result = $this->newResult();
         $connection
-            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn(['count' => 1])
-            ->shouldReceive('getEntries')->once()->with(['count' => 1])->andReturn($group);
+            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)->andReturn($group)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertTrue($group->addMember($member));
     }
@@ -367,9 +373,11 @@ class GroupTest extends TestCase
             ]
         )->andReturn(true);
 
+        $result = $this->newResult();
         $connection
-            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn(['count' => 1])
-            ->shouldReceive('getEntries')->once()->with(['count' => 1])->andReturn($group);
+            ->shouldReceive('read')->once()->with($group->getDn(), '(objectclass=*)', ['*'], false, 1)->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)->andReturn($group)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertTrue($group->removeMember($member));
     }

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -96,10 +96,11 @@ class ModelTest extends TestCase
             'dn'             => 'dc=corp,dc=org',
         ];
 
+        $result = $this->newResult();
         $connection = $this->newConnectionMock();
-
-        $connection->shouldReceive('read')->once()->andReturn($connection);
-        $connection->shouldReceive('getEntries')->once()->andReturn([$attributes]);
+        $connection->shouldReceive('read')->once()->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result)->andReturn([$attributes]);
+        $connection->shouldReceive('freeResult')->once()->with($result);
 
         $connection->shouldReceive('modReplace')->once()->withArgs(['dc=corp,dc=org', ['cn' => 'John Doe']])->andReturn(true);
 
@@ -117,9 +118,11 @@ class ModelTest extends TestCase
             'dn'             => 'dc=corp,dc=org',
         ];
 
+        $result = $this->newResult();
         $connection = $this->newConnectionMock();
-        $connection->shouldReceive('read')->once()->andReturn($connection);
-        $connection->shouldReceive('getEntries')->once()->andReturn([$attributes]);
+        $connection->shouldReceive('read')->once()->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result)->andReturn([$attributes]);
+        $connection->shouldReceive('freeResult')->once()->with($result);
         $connection->shouldReceive('modDelete')->once()->withArgs(['dc=corp,dc=org', ['cn' => []]])->andReturn(true);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
@@ -137,9 +140,11 @@ class ModelTest extends TestCase
             'dn'             => 'dc=corp,dc=org',
         ];
 
+        $result = $this->newResult();
         $connection = $this->newConnectionMock();
-        $connection->shouldReceive('read')->once()->andReturn($connection);
-        $connection->shouldReceive('getEntries')->once()->andReturn([$attributes]);
+        $connection->shouldReceive('read')->once()->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result)->andReturn([$attributes]);
+        $connection->shouldReceive('freeResult')->once()->with($result);
         $connection->shouldReceive('modDelete')->once()->withArgs(['dc=corp,dc=org', [
             'cn' => [], 'memberof' => [],
         ]])->andReturn(true);
@@ -162,10 +167,11 @@ class ModelTest extends TestCase
             'dn'             => 'dc=corp,dc=org',
         ];
 
+        $result = $this->newResult();
         $connection = $this->newConnectionMock();
-
-        $connection->shouldReceive('read')->once()->andReturn($connection);
-        $connection->shouldReceive('getEntries')->once()->andReturn([$attributes]);
+        $connection->shouldReceive('read')->once()->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result)->andReturn([$attributes]);
+        $connection->shouldReceive('freeResult')->once()->with($result);
         $connection->shouldReceive('modAdd')->once()->withArgs(['dc=corp,dc=org', ['givenName' => 'John Doe']])->andReturn(true);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
@@ -232,14 +238,18 @@ class ModelTest extends TestCase
             ],
         ];
 
+        $result = $this->newResult();
         $connection = $this->newConnectionMock();
 
         $connection->shouldReceive('add')->withArgs(['cn=John Doe,ou=Accounting,dc=corp,dc=org', $attributes])->andReturn(true);
-        $connection->shouldReceive('read')->withArgs(['cn=John Doe,ou=Accounting,dc=corp,dc=org', '(objectclass=*)', [], false, 0])->andReturn('resource');
+        $connection->shouldReceive('read')->withArgs(['cn=John Doe,ou=Accounting,dc=corp,dc=org', '(objectclass=*)', [], false, 0])->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
+        $connection->shouldReceive('freeResult')->with($result);
 
-        $connection->shouldReceive('read')->andReturn($connection);
+        $result = $this->newResult();
+        $connection->shouldReceive('read')->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
+        $connection->shouldReceive('freeResult')->with($result);
 
         $connection->shouldReceive('close')->andReturn(true);
 
@@ -268,8 +278,10 @@ class ModelTest extends TestCase
             ],
         ];
 
-        $connection->shouldReceive('read')->andReturn($connection);
-        $connection->shouldReceive('getEntries')->andReturn($attributes);
+        $result = $this->newResult();
+        $connection->shouldReceive('read')->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result)->andReturn($attributes);
+        $connection->shouldReceive('freeResult')->once()->with($result);
         $connection->shouldReceive('modifyBatch')->once()->withArgs([$dn, [$modification]])->andReturn(true);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
@@ -301,11 +313,15 @@ class ModelTest extends TestCase
             ],
         ];
 
+        $result = $this->newResult();
         $connection->shouldReceive('add')->withArgs([$dn, $attributes])->andReturn(true);
-        $connection->shouldReceive('read')->withArgs([$dn, '(objectclass=*)', [], false, 0])->andReturn('resource');
+        $connection->shouldReceive('read')->withArgs([$dn, '(objectclass=*)', [], false, 0])->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
-        $connection->shouldReceive('read')->andReturn($connection);
+        $connection->shouldReceive('freeResult')->with($result);
+        $result = $this->newResult();
+        $connection->shouldReceive('read')->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
+        $connection->shouldReceive('freeResult')->with($result);
 
         $entry = $this->newModel($attributes, $this->newBuilder($connection));
 
@@ -339,11 +355,15 @@ class ModelTest extends TestCase
             ],
         ];
 
+        $result = $this->newResult();
         $connection->shouldReceive('add')->withArgs([$dn, $attributes])->andReturn(true);
-        $connection->shouldReceive('read')->withArgs([$dn, '(objectclass=*)', [], false, 0])->andReturn('resource');
+        $connection->shouldReceive('read')->withArgs([$dn, '(objectclass=*)', [], false, 0])->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
-        $connection->shouldReceive('read')->andReturn($connection);
+        $connection->shouldReceive('freeResult')->with($result);
+        $result = $this->newResult();
+        $connection->shouldReceive('read')->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
+        $connection->shouldReceive('freeResult')->with($result);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
 
@@ -371,8 +391,10 @@ class ModelTest extends TestCase
             ],
         ];
 
-        $connection->shouldReceive('read')->andReturn($connection);
+        $result = $this->newResult();
+        $connection->shouldReceive('read')->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
+        $connection->shouldReceive('freeResult')->with($result);
         $connection->shouldReceive('modifyBatch')->once()->withArgs([$dn, [$modification]])->andReturn(true);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
@@ -414,8 +436,10 @@ class ModelTest extends TestCase
             ],
         ];
 
-        $connection->shouldReceive('read')->andReturn($connection);
+        $result = $this->newResult();
+        $connection->shouldReceive('read')->andReturn($result);
         $connection->shouldReceive('getEntries')->andReturn($returnedRaw);
+        $connection->shouldReceive('freeResult')->with($result);
         $connection->shouldReceive('modifyBatch')->once()->withArgs([$dn, $modifications])->andReturn(true);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
@@ -503,8 +527,8 @@ class ModelTest extends TestCase
         $this->assertEquals($date, $model->getUpdatedAt());
         $this->assertEquals('2015-05-19 03:49:50', $model->getCreatedAtDate());
         $this->assertEquals('2015-05-19 03:49:50', $model->getUpdatedAtDate());
-        $this->assertInternalType('int', $model->getCreatedAtTimestamp());
-        $this->assertInternalType('int', $model->getUpdatedAtTimestamp());
+        $this->assertIsInt($model->getCreatedAtTimestamp());
+        $this->assertIsInt($model->getUpdatedAtTimestamp());
     }
 
     public function test_convert_string_to_bool()
@@ -576,10 +600,12 @@ class ModelTest extends TestCase
             true,
         ];
 
+        $result = $this->newResult();
         $connection
             ->shouldReceive('rename')->once()->withArgs($args)->andReturn(true)
-            ->shouldReceive('read')->once()
-            ->shouldReceive('getEntries')->once();
+            ->shouldReceive('read')->once()->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
 
@@ -603,10 +629,12 @@ class ModelTest extends TestCase
             true,
         ];
 
+        $result = $this->newResult();
         $connection
             ->shouldReceive('rename')->once()->withArgs($args)->andReturn(true)
-            ->shouldReceive('read')->once()
-            ->shouldReceive('getEntries')->once();
+            ->shouldReceive('read')->once()->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $entry = $this->newModel([], $this->newBuilder($connection));
 
@@ -632,9 +660,11 @@ class ModelTest extends TestCase
             1,
         ];
 
+        $result = $this->newResult();
         $connection->shouldReceive('add')->once()->withArgs($addArgs)->andReturn(true);
-        $connection->shouldReceive('read')->once()->withArgs($readArgs)->andReturn(true);
-        $connection->shouldReceive('getEntries')->once()->andReturn([]);
+        $connection->shouldReceive('read')->once()->withArgs($readArgs)->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result)->andReturn([]);
+        $connection->shouldReceive('freeResult')->once()->with($result);
 
         $builder = $this->newBuilder($connection);
 
@@ -686,8 +716,10 @@ class ModelTest extends TestCase
 
         $model->setRawAttributes(compact('dn'));
 
-        $connection->shouldReceive('read')->once()->withArgs([$dn, '(objectclass=*)', ['*'], false, 1]);
-        $connection->shouldReceive('getEntries')->once()->andReturn(['count' => 1, ['dn' => 'cn=Jane Doe']]);
+        $result = $this->newResult();
+        $connection->shouldReceive('read')->once()->withArgs([$dn, '(objectclass=*)', ['*'], false, 1])->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result)->andReturn(['count' => 1, ['dn' => 'cn=Jane Doe']]);
+        $connection->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertTrue($model->syncRaw());
         $this->assertEquals('cn=Jane Doe', $model->getDn());
@@ -699,9 +731,11 @@ class ModelTest extends TestCase
 
         $modification = new BatchModification('cn', 3, ['Jane Doe']);
 
+        $result = $this->newResult();
         $connection->shouldReceive('modifyBatch')->once()->withArgs(['cn=John Doe,dc=acme,dc=org', [$modification->get()]])->andReturn(true);
-        $connection->shouldReceive('read')->once()->andReturn(true);
-        $connection->shouldReceive('getEntries')->once();
+        $connection->shouldReceive('read')->once()->andReturn($result);
+        $connection->shouldReceive('getEntries')->once()->with($result);
+        $connection->shouldReceive('freeResult')->once()->with($result);
 
         $builder = $this->newBuilder($connection);
 
@@ -986,10 +1020,12 @@ class ModelTest extends TestCase
             $firedCreated = true;
         });
 
+        $result = $this->newResult();
         $c
             ->shouldReceive('add')->once()->andReturn(true)
-            ->shouldReceive('read')->once()
-            ->shouldReceive('getEntries')->once();
+            ->shouldReceive('read')->once()->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $m->save([
             'dn' => 'cn=jdoe,dc=acme,dc=org',
@@ -1026,10 +1062,12 @@ class ModelTest extends TestCase
             $firedUpdated = true;
         });
 
+        $result = $this->newResult();
         $c
             ->shouldReceive('modifyBatch')->once()->andReturn(true)
-            ->shouldReceive('read')->once()
-            ->shouldReceive('getEntries')->once();
+            ->shouldReceive('read')->once()->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $m->save([
             'cn' => 'new',

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -714,10 +714,12 @@ class BuilderTest extends TestCase
             ],
         ];
 
+        $result = $this->newResult();
         $connection->shouldReceive('controlPagedResult')->twice()
-            ->shouldReceive('search')->once()->withArgs(['', '(field=\76\61\6c\75\65)', ['*'], false, 0])->andReturn('resource')
-            ->shouldReceive('controlPagedResultResponse')->withArgs(['resource', ''])
-            ->shouldReceive('getEntries')->andReturn($rawEntries);
+            ->shouldReceive('search')->once()->withArgs(['', '(field=\76\61\6c\75\65)', ['*'], false, 0])->andReturn($result)
+            ->shouldReceive('controlPagedResultResponse')->withArgs([$result, ''])
+            ->shouldReceive('getEntries')->with($result)->andReturn($rawEntries)
+            ->shouldReceive('freeResult')->with($result);
 
         $b = $this->newBuilder($connection);
 
@@ -774,9 +776,11 @@ class BuilderTest extends TestCase
         $controls = ['1.2.840.113556.1.4.319' => ['oid' => '1.2.840.113556.1.4.319', 'isCritical' => true, 'value' => ['size' => 50, 'cookie' => '']]];
         $connection->shouldReceive('setOption')->once()->withArgs([18, $controls]);
 
-        $connection->shouldReceive('search')->once()->withArgs(['', '(field=\76\61\6c\75\65)', ['*'], false, 0])->andReturn('resource');
-        $connection->shouldReceive('parseResult')->once()->withArgs(['resource', null, null, null, null, $controls]);
-        $connection->shouldReceive('getEntries')->andReturn($rawEntries);
+        $result = $this->newResult();
+        $connection->shouldReceive('search')->once()->withArgs(['', '(field=\76\61\6c\75\65)', ['*'], false, 0])->andReturn($result);
+        $connection->shouldReceive('parseResult')->once()->withArgs([$result, null, null, null, null, $controls]);
+        $connection->shouldReceive('getEntries')->with($result)->andReturn($rawEntries);
+        $connection->shouldReceive('freeResult')->with($result);
 
         $connection->shouldReceive('setOption')->once()->withArgs([18, []]);
 
@@ -1057,9 +1061,11 @@ class BuilderTest extends TestCase
 
         $s->shouldReceive('objectClass')->andReturn('objectclass');
 
+        $result = $this->newResult();
         $c
-            ->shouldReceive('read')->once()->with('cn=John Doe,dc=acme,dc=org', '(objectclass=*)', [0 => '*'], false, 1)
-            ->shouldReceive('getEntries')->once()->andReturn($rawEntries);
+            ->shouldReceive('read')->once()->with('cn=John Doe,dc=acme,dc=org', '(objectclass=*)', [0 => '*'], false, 1)->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)->andReturn($rawEntries)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertEquals($rawEntries[0], $b->raw()->findByDn($dn));
     }
@@ -1093,9 +1099,11 @@ class BuilderTest extends TestCase
             'objectclass',
         ]);
 
+        $result = $this->newResult();
         $c
-            ->shouldReceive('search')->once()->with(null, $expectedFilter, $expectedSelect, $attrsOnly = false, $total = 1)->andReturnSelf()
-            ->shouldReceive('getEntries')->once()->andReturn(null);
+            ->shouldReceive('search')->once()->with(null, $expectedFilter, $expectedSelect, $attrsOnly = false, $total = 1)->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)->andReturn(null)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertNull($b->find('jdoe', $select));
     }
@@ -1135,9 +1143,11 @@ class BuilderTest extends TestCase
             'objectclass',
         ]);
 
+        $result = $this->newResult();
         $c
-            ->shouldReceive('search')->once()->with(null, $expectedFilter, $expectedSelect, $attrsOnly = false, $total = 0)->andReturnSelf()
-            ->shouldReceive('getEntries')->once()->andReturn(null);
+            ->shouldReceive('search')->once()->with(null, $expectedFilter, $expectedSelect, $attrsOnly = false, $total = 0)->andReturn($result)
+            ->shouldReceive('getEntries')->once()->with($result)->andReturn(null)
+            ->shouldReceive('freeResult')->once()->with($result);
 
         $this->assertInstanceOf(Collection::class, $b->findMany([
             'john',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,8 +51,24 @@ class TestCase extends \PHPUnit\Framework\TestCase
         });
 
         parent::tearDown();
+    }
 
+    /**
+     * @return void
+     */
+    protected function assertPostConditions()
+    {
         $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+
+        if (method_exists($this, "markAsRisky")) {
+            foreach (Mockery::getContainer()->mockery_thrownExceptions() as $e) {
+                if (!$e->dismissed()) {
+                    $this->markAsRisky();
+                }
+            }
+        }
+
+        Mockery::close();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,14 +8,16 @@ use Adldap\Models\User;
 use Adldap\Query\Builder;
 use Adldap\Query\Grammar;
 use Adldap\Connections\ConnectionInterface;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use LDAP\Result;
 
-class TestCase extends MockeryTestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /*
      * Set up the test environment.
+     *
+     * @return void
      */
-    protected function setUp(): void
+    protected function setUp()
     {
         if (!defined('LDAP_CONTROL_PAGEDRESULTS')) {
             define('LDAP_CONTROL_PAGEDRESULTS', '1.2.840.113556.1.4.319');
@@ -39,13 +41,18 @@ class TestCase extends MockeryTestCase
         }
     }
 
-    protected function tearDown(): void
+    /**
+     * @return void
+     */
+    protected function tearDown()
     {
         User::usePasswordStrategy(function ($password) {
             return Utilities::encodePassword($password);
         });
 
         parent::tearDown();
+
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
     }
 
     /**
@@ -96,5 +103,14 @@ class TestCase extends MockeryTestCase
     protected function newConnectionMock()
     {
         return $this->mock(ConnectionInterface::class);
+    }
+
+    /**
+     * Returns a mocked LDAP result.
+     * @return Result
+     */
+    protected function newResult()
+    {
+        return $this->mock(Result::class);
     }
 }


### PR DESCRIPTION
Hi,

This package got my attention since it was mentionned in the PHP's internals mailing list: https://externals.io/message/116519#116554

This PR makes the tests pass with PHP 7.0 up to PHP 8.0.
There is more work to do to make it fully compatible with PHP 8.1, but before that I wanted to know if you'll accept this changes since you work on LdapRecord now.