### PR TITLE
Fix tests and deprecation messages in PHP 8.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,6 @@ on:
 jobs:
   test:
     runs-on: "ubuntu-latest"
-    continue-on-error: ${{ matrix.experimental == true }}
 
     strategy:
       matrix:
@@ -32,10 +31,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
-
-        include:
-          - php-version: "8.1"
-            experimental: true
+          - "8.1"
 
     name: PHP ${{ matrix.php-version }} tests
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,5 +21,6 @@
     </filter>
     <php>
         <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="/.*/" />
     </php>
 </phpunit>

--- a/src/Configuration/DomainConfiguration.php
+++ b/src/Configuration/DomainConfiguration.php
@@ -150,7 +150,7 @@ class DomainConfiguration
             $validator = new Validators\IntegerValidator($key, $value);
         } elseif (is_bool($default)) {
             $validator = new Validators\BooleanValidator($key, $value);
-        } elseif (class_exists($default)) {
+        } elseif (is_string($default) && class_exists($default)) {
             $validator = new Validators\ClassValidator($key, $value);
         } else {
             $validator = new Validators\StringOrNullValidator($key, $value);

--- a/src/Configuration/Validators/ClassValidator.php
+++ b/src/Configuration/Validators/ClassValidator.php
@@ -15,7 +15,7 @@ class ClassValidator extends Validator
      */
     public function validate()
     {
-        if (!class_exists($this->value)) {
+        if (!is_string($this->value) || !class_exists($this->value)) {
             throw new ConfigurationException("Option {$this->key} must be a valid class.");
         }
 

--- a/src/Models/Attributes/DistinguishedName.php
+++ b/src/Models/Attributes/DistinguishedName.php
@@ -52,7 +52,7 @@ class DistinguishedName
         foreach ($this->components as $component => $values) {
             array_map(function ($value) use ($component, &$components) {
                 // Assemble the component and escape the value.
-                $components[] = sprintf('%s=%s', $component, ldap_escape($value, '', 2));
+                $components[] = sprintf('%s=%s', $component, ldap_escape((string) $value, '', 2));
             }, $values);
         }
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -171,6 +171,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return !is_null($this->getAttribute($offset));
@@ -183,6 +184,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getAttribute($offset);
@@ -196,6 +198,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->setAttribute($offset, $value);
@@ -208,6 +211,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->attributes[$offset]);
@@ -230,6 +234,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $attributes = $this->getAttributes();
@@ -828,6 +833,10 @@ abstract class Model implements ArrayAccess, JsonSerializable
     public function getMaxPasswordAgeDays()
     {
         $age = $this->getMaxPasswordAge();
+
+        if ($age === null) {
+            return 0;
+        }
 
         return (int) (abs($age) / 10000000 / 60 / 60 / 24);
     }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -327,6 +327,10 @@ class User extends Entry implements Authenticatable
     {
         $workstations = $this->getFirstAttribute($this->schema->userWorkstations());
 
+        if ($workstations === null) {
+            return [];
+        }
+
         return array_filter(explode(',', $workstations));
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1092,7 +1092,7 @@ class Builder
         // We'll escape the value if raw isn't requested.
         $value = $raw ? $value : $this->escape($value);
 
-        $field = $this->escape($field, $ignore = null, 3);
+        $field = $this->escape($field, $ignore = '', 3);
 
         $this->addFilter($boolean, compact('field', 'operator', 'value'));
 
@@ -1706,7 +1706,7 @@ class Builder
      */
     public function escape($value, $ignore = '', $flags = 0)
     {
-        return ldap_escape($value, $ignore, $flags);
+        return ldap_escape((string) $value, $ignore, $flags);
     }
 
     /**

--- a/src/Query/Paginator.php
+++ b/src/Query/Paginator.php
@@ -65,6 +65,7 @@ class Paginator implements Countable, IteratorAggregate
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $entries = array_slice($this->getResults(), $this->getCurrentOffset(), $this->getPerPage(), true);
@@ -129,6 +130,7 @@ class Paginator implements Countable, IteratorAggregate
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->results);

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -153,7 +153,7 @@ class Processor
      */
     public function newModel($attributes = [], $model = null)
     {
-        $model = (class_exists($model) ? $model : $this->schema->entryModel());
+        $model = ($model !== null && class_exists($model) ? $model : $this->schema->entryModel());
 
         if (!is_subclass_of($model, $base = Model::class)) {
             throw new InvalidArgumentException("The given model class '{$model}' must extend the base model class '{$base}'");
@@ -200,7 +200,7 @@ class Processor
     {
         $field = $this->builder->getSortByField();
 
-        $flags = $this->builder->getSortByFlags();
+        $flags = $this->builder->getSortByFlags() ?? \SORT_REGULAR;
 
         $direction = $this->builder->getSortByDirection();
 

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -105,7 +105,7 @@ class Utilities
      */
     public static function binaryGuidToString($binGuid)
     {
-        if (trim($binGuid) == '' || is_null($binGuid)) {
+        if ($binGuid === null || trim($binGuid) === '') {
             return;
         }
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -809,7 +809,7 @@ class BuilderTest extends TestCase
 
         $b->where($field, '=', $value);
 
-        $escapedField = ldap_escape($field, null, 3);
+        $escapedField = ldap_escape($field, '', 3);
 
         $escapedValue = ldap_escape($value);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,6 @@ use Adldap\Models\User;
 use Adldap\Query\Builder;
 use Adldap\Query\Grammar;
 use Adldap\Connections\ConnectionInterface;
-use LDAP\Result;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
@@ -122,11 +121,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Returns a mocked LDAP result.
-     * @return Result
+     * Returns a faked LDAP Result resource.
+     *
+     * @return resource
      */
     protected function newResult()
     {
-        return $this->mock(Result::class);
+        // cheap way of creating a PHP resource
+        return stream_context_create();
     }
 }


### PR DESCRIPTION
All deprecation messages raised during tests execution are now fixed. Tests are green too.

I cannot guarantee there is no deprecation messages still hidden in the code, but we will need static analysis tools to find them.

I've tried to have a minimal impact with this PR to let the behaviour and the interfaces unchanged.