### PR TITLE
Increase range limitation when paginating members

### DIFF
--- a/src/Models/Group.php
+++ b/src/Models/Group.php
@@ -237,7 +237,7 @@ class Group extends Entry
         $key = reset($attributes);
 
         preg_match_all(
-            '/member;range\=([0-9]{1,4})-([0-9*]{1,4})/',
+            '/member;range\=([0-9]{1,5})-([0-9*]{1,5})/',
             $key,
             $matches
         );


### PR DESCRIPTION
A user that has active directory groups with more than 10k members will not be able to go through all of them.

Issue https://github.com/Adldap2/Adldap2/issues/803