### PR TITLE
Check binary SID for emptiness

### DIFF
--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -57,7 +57,7 @@ class Utilities
      */
     public static function binarySidToString($value)
     {
-        if ($value === '') {
+        if (empty($value)) {
             return;
         }
 


### PR DESCRIPTION
We are getting "unpack(): Type C: not enough input, need 1, have 0" error when use adldap in our synchronization with ActiveDirectory. It happens when value is empty, so it could not be unpacked