### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "php": ">=7.0",
         "ext-ldap": "*",
         "ext-json": "*",
-        "psr/log": "~1.0|~2.0|~3.0",
-        "psr/simple-cache": "~1.0|~2.0",
-        "tightenco/collect": "~5.0|~6.0|~7.0|~8.0",
-        "illuminate/contracts": "~5.0|~6.0|~7.0|~8.0|~9.0"
+        "psr/log": "^1.0|^2.0|^3.0",
+        "psr/simple-cache": "^1.0|^2.0|^3.0",
+        "illuminate/contracts": "^8.0|^9.0",
+        "illuminate/collections": "^8.0|^9.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~5.2|~6.0",


### PR DESCRIPTION
- replace `tightenco/collect` with `illuminate/collections`
- allow `psr/simple-cache:^3.0`
- use caret instead of tilde operator

This is a breaking change as `illuminate/collections` is not available < 8.0.
Therefore the minimum required PHP version could be bumped to ^8.0 too.