### PR TITLE
Allow closing a LDAP connection in PHP 8.1+

### DIFF
--- a/src/Connections/Ldap.php
+++ b/src/Connections/Ldap.php
@@ -26,7 +26,7 @@ class Ldap implements ConnectionInterface
     /**
      * The active LDAP connection.
      *
-     * @var resource
+     * @var resource|\LDAP\Connection
      */
     protected $connection;
 
@@ -271,7 +271,7 @@ class Ldap implements ConnectionInterface
     {
         $connection = $this->connection;
 
-        $result = is_resource($connection) ? ldap_close($connection) : false;
+        $result = (is_resource($connection) || $connection instanceof \LDAP\Connection) ? ldap_close($connection) : false;
 
         $this->bound = false;
 


### PR DESCRIPTION
Hey, this pull requests solves a problem where you couldn't close a LDAP connection in PHP 8.1+

Thanks for looking it over 🙂